### PR TITLE
feat: 팝업스토어의 좋아요 및 방문자 기능 추가 및 Batch 모듈 생성

### DIFF
--- a/backend/pcloud-api/docs/asciidoc/popups.adoc
+++ b/backend/pcloud-api/docs/asciidoc/popups.adoc
@@ -76,3 +76,16 @@ include::{snippets}/popups-controller-web-mvc-test/patch_popups/http-request.ado
 === Response
 
 include::{snippets}/popups-controller-web-mvc-test/patch_popups/http-response.adoc[]
+
+== 팝업스토어를 좋아요 처리 및 취소한다 (POST /api/popups/{popupsId}/likes)
+
+=== Request
+
+include::{snippets}/popups-controller-web-mvc-test/likes_popups/request-headers.adoc[]
+include::{snippets}/popups-controller-web-mvc-test/likes_popups/path-parameters.adoc[]
+include::{snippets}/popups-controller-web-mvc-test/likes_popups/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/popups-controller-web-mvc-test/likes_popups/response-fields.adoc[]
+include::{snippets}/popups-controller-web-mvc-test/likes_popups/http-response.adoc[]

--- a/backend/pcloud-api/src/main/java/com/api/global/slack/SlackAppender.java
+++ b/backend/pcloud-api/src/main/java/com/api/global/slack/SlackAppender.java
@@ -22,9 +22,9 @@ public class SlackAppender extends AppenderBase<ILoggingEvent> {
     private Map<String, Object> createSlackErrorBody(final ILoggingEvent eventObject) {
         String message = createMessage(eventObject);
         return Map.of("channel", "#에러-발생",
-                "fallback", "요청을 실패했어요 :cry:",
+                "fallback", "API 서버에서 요청을 실패했어요 :cry:",
                 "color", "#2eb886",
-                "pretext", "에러가 발생했어요 확인해주세요 :cry:",
+                "pretext", "API 서버에서 에러가 발생했어요 확인해주세요 :cry:",
                 "author_name", "pop-cloud",
                 "text", message,
                 "fields",

--- a/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
@@ -45,7 +45,7 @@ public class PopupsService {
                 .orElseThrow(() -> new PopupsException(POPUPS_NOT_FOUND_EXCEPTION));
     }
 
-    // TODO: 동시성 이슈 발생 추후 처리 예정
+    // TODO: 동시성 이슈 발생 추후 처리 예정 (#14 Issue 이후 작업)
     public boolean likes(final Long memberId, final Long popupsId) {
         Popups popups = findPopups(popupsId);
         boolean canAddLikes = handlePopupsLikes(popupsId, memberId);

--- a/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
@@ -45,6 +45,7 @@ public class PopupsService {
                 .orElseThrow(() -> new PopupsException(POPUPS_NOT_FOUND_EXCEPTION));
     }
 
+    // TODO: 동시성 이슈 발생 추후 처리 예정
     public boolean likes(final Long memberId, final Long popupsId) {
         Popups popups = findPopups(popupsId);
         boolean canAddLikes = handlePopupsLikes(popupsId, memberId);

--- a/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/application/PopupsService.java
@@ -4,6 +4,7 @@ import com.api.popups.application.request.PopupsCreateRequest;
 import com.api.popups.application.request.PopupsUpdateRequest;
 import com.common.config.event.Events;
 import com.domain.domains.common.CustomTagType;
+import com.domain.domains.popups.domain.LikedPopups;
 import com.domain.domains.popups.domain.Popups;
 import com.domain.domains.popups.domain.PopupsRepository;
 import com.domain.domains.popups.event.PopupsTagsCreatedEvents;
@@ -42,5 +43,22 @@ public class PopupsService {
     private Popups findPopups(final Long popupsId) {
         return popupsRepository.findById(popupsId)
                 .orElseThrow(() -> new PopupsException(POPUPS_NOT_FOUND_EXCEPTION));
+    }
+
+    public boolean likes(final Long memberId, final Long popupsId) {
+        Popups popups = findPopups(popupsId);
+        boolean canAddLikes = handlePopupsLikes(popupsId, memberId);
+        popups.addLikedCount(canAddLikes);
+        return canAddLikes;
+    }
+
+    private boolean handlePopupsLikes(final Long popupsId, final Long memberId) {
+        if (popupsRepository.existsByProductIdAndMemberId(memberId, popupsId)) {
+            popupsRepository.deleteLikedPopupsByPopupsIdAndMemberId(popupsId, memberId);
+            return false;
+        }
+
+        popupsRepository.saveLikedPopups(LikedPopups.of(popupsId, memberId));
+        return true;
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/popups/infrastructure/PopupsRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/infrastructure/PopupsRepositoryImpl.java
@@ -1,9 +1,11 @@
 package com.api.popups.infrastructure;
 
+import com.domain.domains.popups.domain.LikedPopups;
 import com.domain.domains.popups.domain.Popups;
 import com.domain.domains.popups.domain.PopupsRepository;
 import com.domain.domains.popups.domain.response.PopupsSimpleResponse;
 import com.domain.domains.popups.domain.response.PopupsSpecificResponse;
+import com.domain.domains.popups.infrastructure.LikedPopupsJpaRepository;
 import com.domain.domains.popups.infrastructure.PopupsJpaRepository;
 import com.domain.domains.popups.infrastructure.PopupsQueryRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ public class PopupsRepositoryImpl implements PopupsRepository {
 
     private final PopupsJpaRepository popupsJpaRepository;
     private final PopupsQueryRepository popupsQueryRepository;
+    private final LikedPopupsJpaRepository likedPopupsJpaRepository;
 
     @Override
     public Optional<Popups> findById(final Long id) {
@@ -37,5 +40,20 @@ public class PopupsRepositoryImpl implements PopupsRepository {
     @Override
     public List<PopupsSimpleResponse> findAllWithPaging(final Long popupsId, final Integer pageSize) {
         return popupsQueryRepository.findAllWithPaging(popupsId, pageSize);
+    }
+
+    @Override
+    public boolean existsByProductIdAndMemberId(final Long popupsId, final Long memberId) {
+        return likedPopupsJpaRepository.existsByPopupsIdAndMemberId(popupsId, memberId);
+    }
+
+    @Override
+    public void deleteLikedPopupsByPopupsIdAndMemberId(final Long popupsId, final Long memberId) {
+        likedPopupsJpaRepository.deleteByPopupsIdAndMemberId(popupsId, memberId);
+    }
+
+    @Override
+    public LikedPopups saveLikedPopups(final LikedPopups likedPopups) {
+        return likedPopupsJpaRepository.save(likedPopups);
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/popups/presentation/PopupsController.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/presentation/PopupsController.java
@@ -4,6 +4,7 @@ import com.api.popups.application.PopupsQueryService;
 import com.api.popups.application.PopupsService;
 import com.api.popups.application.request.PopupsCreateRequest;
 import com.api.popups.application.request.PopupsUpdateRequest;
+import com.api.popups.presentation.response.PopupLikedStatusResponse;
 import com.domain.annotation.AuthMember;
 import com.domain.annotation.AuthMembers;
 import com.domain.domains.popups.domain.response.PopupsSimpleResponse;
@@ -55,6 +56,9 @@ public class PopupsController {
         return ResponseEntity.ok(popupsQueryService.findAll(popupsId, pageSize));
     }
 
+    /**
+     * TODO : 조회시 방문자 수 처리하기
+     */
     @GetMapping("/{popupsId}")
     public ResponseEntity<PopupsSpecificResponse> findById(@PathVariable final Long popupsId) {
         return ResponseEntity.ok(popupsQueryService.findById(popupsId));
@@ -69,5 +73,14 @@ public class PopupsController {
         popupsService.patchById(memberId, popupsId, request);
         return ResponseEntity.noContent()
                 .build();
+    }
+
+    @PostMapping("/{popupsId}/likes")
+    public ResponseEntity<PopupLikedStatusResponse> likes(
+            @AuthMember final Long memberId,
+            @PathVariable final Long popupsId
+    ) {
+        boolean likedStatusAfterActing = popupsService.likes(memberId, popupsId);
+        return ResponseEntity.ok(new PopupLikedStatusResponse(popupsId, likedStatusAfterActing));
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/popups/presentation/PopupsController.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/presentation/PopupsController.java
@@ -57,7 +57,7 @@ public class PopupsController {
     }
 
     /**
-     * TODO : 조회시 방문자 수 처리하기
+     * TODO : 조회시 방문자 수 처리하기 (#14 Issue 이후 작업)
      */
     @GetMapping("/{popupsId}")
     public ResponseEntity<PopupsSpecificResponse> findById(@PathVariable final Long popupsId) {

--- a/backend/pcloud-api/src/main/java/com/api/popups/presentation/response/PopupLikedStatusResponse.java
+++ b/backend/pcloud-api/src/main/java/com/api/popups/presentation/response/PopupLikedStatusResponse.java
@@ -1,0 +1,7 @@
+package com.api.popups.presentation.response;
+
+public record PopupLikedStatusResponse(
+        Long popupsId,
+        boolean isStatusLiked
+) {
+}

--- a/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerAcceptanceFixture.java
+++ b/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerAcceptanceFixture.java
@@ -4,6 +4,7 @@ import com.api.helper.AcceptanceBaseFixture;
 import com.api.popups.application.request.PopupsCreateRequest;
 import com.api.popups.application.request.PopupsUpdateRequest;
 import com.api.popups.fixture.request.PopupsRequestFixtures;
+import com.api.popups.presentation.response.PopupLikedStatusResponse;
 import com.domain.domains.popups.domain.Popups;
 import com.domain.domains.popups.domain.PopupsRepository;
 import io.restassured.RestAssured;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus;
 
 import static com.api.popups.fixture.request.PopupsRequestFixtures.팝업스토어_업데이트_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static popups.fixture.PopupsFixture.일반_팝업_스토어_생성_뷰티;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -90,5 +92,24 @@ class PopupsControllerAcceptanceFixture extends AcceptanceBaseFixture {
 
     protected void 팝업스토어_업데이트_결과_검증(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    protected ExtractableResponse<Response> 팝업스토어_좋아요_요청() {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + 일반_유저_토큰)
+                .when()
+                .post("/popups/1/likes")
+                .then().log().all()
+                .extract();
+    }
+
+    protected void 팝업스토어_좋아요_결과_검증(final ExtractableResponse<Response> response) {
+        PopupLikedStatusResponse responseBody = response.as(PopupLikedStatusResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat(responseBody.popupsId()).isEqualTo(1L);
+            softly.assertThat(responseBody.isStatusLiked()).isTrue();
+        });
     }
 }

--- a/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerAcceptanceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerAcceptanceTest.java
@@ -56,4 +56,16 @@ class PopupsControllerAcceptanceTest extends PopupsControllerAcceptanceFixture {
         // then
         팝업스토어_업데이트_결과_검증(요청_결과);
     }
+
+    @Test
+    void 팝업스토어_좋아요_처리() {
+        // given
+        팝업_스토어_생성();
+
+        // when
+        var 요청_결과 = 팝업스토어_좋아요_요청();
+
+        // then
+        팝업스토어_좋아요_결과_검증(요청_결과);
+    }
 }

--- a/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerWebMvcTest.java
@@ -187,4 +187,28 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                         )
                 ));
     }
+
+    @Test
+    void 팝업스토어를_좋아요_처리한다() throws Exception {
+        // given
+        when(popupsService.likes(any(), any())).thenReturn(true);
+
+        // when & then
+        mockMvc.perform(post("/popups/{popupsId}/likes", 1)
+                        .header(AUTHORIZATION, "Bearer tokenInfo ~~")
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isOk())
+                .andDo(customDocument("likes_popups",
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION).description("유저 토큰 정보")
+                        ),
+                        pathParameters(
+                                parameterWithName("popupsId").description("팝업스토어 id")
+                        ),
+                        responseFields(
+                                fieldWithPath("popupsId").description("팝업스토어 id"),
+                                fieldWithPath("isStatusLiked").description("팝업스토어 좋아요 상태 (true면 좋아요 처리되고, false면 좋아요 취소 처리됨)")
+                        )
+                ));
+    }
 }

--- a/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/popups/presentation/PopupsControllerWebMvcTest.java
@@ -96,7 +96,7 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
     @Test
     void 페이징_조회를_한다() throws Exception {
         // given
-        when(popupsQueryService.findAll(any(), any())).thenReturn(List.of(new PopupsSimpleResponse(1L, "빵빵이 전시회", "서울특별시 마포구", LocalDateTime.now().minusDays(30), LocalDateTime.now())));
+        when(popupsQueryService.findAll(any(), any())).thenReturn(List.of(new PopupsSimpleResponse(1L, "빵빵이 전시회", "서울특별시 마포구", LocalDateTime.now().minusDays(30), LocalDateTime.now(), 0, 0)));
 
         // when & then
         mockMvc.perform(get("/popups")
@@ -113,7 +113,9 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("[].title").description("팝업스토어 이름"),
                                 fieldWithPath("[].location").description("팝업스토어 장소명"),
                                 fieldWithPath("[].startDate").description("팝업스토어 시작일"),
-                                fieldWithPath("[].endDate").description("팝업스토어 종료일")
+                                fieldWithPath("[].endDate").description("팝업스토어 종료일"),
+                                fieldWithPath("[].visitedCount").description("팝업스토어 게시글 방문자 수"),
+                                fieldWithPath("[].likedCount").description("팝업스토어 게시글 좋아요 수")
 
                         )
                 ));
@@ -146,6 +148,8 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("latitude").description("위도"),
                                 fieldWithPath("longitude").description("경도"),
                                 fieldWithPath("publicTag").description("공용 퍼블릭 태그"),
+                                fieldWithPath("visitedCount").description("팝업스토어 게시글 방문자 수"),
+                                fieldWithPath("likedCount").description("팝업스토어 게시글 좋아요 수"),
                                 fieldWithPath("tags[]").description("커스텀 태그")
                         )
                 ));

--- a/backend/pcloud-batch/build.gradle
+++ b/backend/pcloud-batch/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'java'
+}
+
+group = 'com'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(":pcloud-common")
+    implementation project(":pcloud-domain")
+    implementation project(":pcloud-infrastructure")
+
+    // testFixtures import
+    testImplementation(testFixtures(project(":pcloud-domain")))
+    testImplementation(testFixtures(project(":pcloud-common")))
+
+    // spring web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // actuator, prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/PCloudBatchServerApplication.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/PCloudBatchServerApplication.java
@@ -1,0 +1,14 @@
+package com.batch;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+
+@ConfigurationPropertiesScan
+@SpringBootApplication
+public class PCloudBatchServerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PCloudBatchServerApplication.class, args);
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/config/RestTemplateConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/config/RestTemplateConfig.java
@@ -1,0 +1,32 @@
+package com.batch.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    private static final int DEFAULT_TIMEOUT_SECOND = 10;
+    private static final int DEFAULT_READ_TIMEOUT_SECOND = 10;
+
+    @Bean
+    public RestTemplate restTemplate(final RestTemplateBuilder restTemplateBuilder) {
+        DefaultUriBuilderFactory defaultUriBuilderFactory = new DefaultUriBuilderFactory();
+        defaultUriBuilderFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECOND))
+                .setReadTimeout(Duration.ofSeconds(DEFAULT_READ_TIMEOUT_SECOND))
+                .additionalMessageConverters(new FormHttpMessageConverter())
+                .additionalMessageConverters(new StringHttpMessageConverter(StandardCharsets.UTF_8))
+                .build();
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/config/SlackAppender.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/config/SlackAppender.java
@@ -1,0 +1,54 @@
+package com.batch.config;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import org.springframework.web.client.RestTemplate;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Map;
+
+public class SlackAppender extends AppenderBase<ILoggingEvent> {
+
+    private static final String WEBHOOK_URL = System.getenv("SLACK_WEBHOOK_URL");
+
+    @Override
+    protected void append(final ILoggingEvent eventObject) {
+        RestTemplate restTemplate = new RestTemplate();
+        Map<String, Object> body = createSlackErrorBody(eventObject);
+        restTemplate.postForEntity(WEBHOOK_URL, body, String.class);
+    }
+
+    private Map<String, Object> createSlackErrorBody(final ILoggingEvent eventObject) {
+        String message = createMessage(eventObject);
+        return Map.of("channel", "#에러-발생",
+                "fallback", "Batch 서버에서 요청을 실패했어요 :cry:",
+                "color", "#2eb886",
+                "pretext", "Batch 서버에서 에러가 발생했어요 확인해주세요 :cry:",
+                "author_name", "pop-cloud",
+                "text", message,
+                "fields",
+                List.of(
+                        Map.of(
+                                "title", "로그 레벨",
+                                "value", eventObject.getLevel().levelStr,
+                                "short", false
+                        ),
+                        "timestamp", eventObject.getTimeStamp()
+                )
+        );
+    }
+
+    private String createMessage(final ILoggingEvent eventObject) {
+        String baseMessage = "에러가 발생했습니다.\n";
+        String pattern = baseMessage + "```%s %s %s [%s] - %s```";
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        return String.format(pattern,
+                simpleDateFormat.format(eventObject.getTimeStamp()),
+                eventObject.getLevel(),
+                eventObject.getThreadName(),
+                eventObject.getLoggerName(),
+                eventObject.getFormattedMessage());
+    }
+}
+

--- a/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/ComponentScanConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/ComponentScanConfig.java
@@ -1,0 +1,9 @@
+package com.batch.config.moduleutils;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(value = {"com.common", "com.domain", "com.infrastructure"})
+public class ComponentScanConfig {
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/PropertySourceScanConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/PropertySourceScanConfig.java
@@ -1,0 +1,16 @@
+package com.batch.config.moduleutils;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@PropertySource(
+        value = {
+                "classpath:application-common-${spring.profiles.active}.yml",
+                "classpath:application-domain-${spring.profiles.active}.yml",
+                "classpath:application-infrastructure-${spring.profiles.active}.yml"
+        },
+        factory = YamlPropertySourceFactory.class
+)
+@Configuration
+public class PropertySourceScanConfig {
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/YamlPropertySourceFactory.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/config/moduleutils/YamlPropertySourceFactory.java
@@ -1,0 +1,16 @@
+package com.batch.config.moduleutils;
+
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.io.support.DefaultPropertySourceFactory;
+import org.springframework.core.io.support.EncodedResource;
+
+public class YamlPropertySourceFactory extends DefaultPropertySourceFactory {
+
+    @Override
+    public org.springframework.core.env.PropertySource<?> createPropertySource(final String name, final EncodedResource resource) {
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(resource.getResource());
+        return new PropertiesPropertySource(resource.getResource().getFilename(), factory.getObject());
+    }
+}

--- a/backend/pcloud-batch/src/main/resources/application.yml
+++ b/backend/pcloud-batch/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8081
+  shutdown: graceful
+
+spring:
+  profiles:
+    active: local
+
+management:
+  server:
+    port: 9001
+  endpoints:
+    web:
+      exposure:
+        include: prometheus, health

--- a/backend/pcloud-batch/src/main/resources/logback-spring.xml
+++ b/backend/pcloud-batch/src/main/resources/logback-spring.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration scan="true" scanPeriod="60 seconds">
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/spring.log}"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <include resource="org/springframework/boot/logging/logback/file-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <appender name="SLACK_APPENDER" class="com.batch.config.SlackAppender">
+    </appender>
+
+    <appender name="ASYNC_SLACK_APPENDER" class="ch.qos.logback.classic.AsyncAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <appender-ref ref="SLACK_APPENDER"/>
+    </appender>
+
+    <springProfile name="!local">
+        <logger name="com.batch" level="DEBUG" additivity="true">
+            <appender-ref ref="ASYNC_SLACK_APPENDER"/>
+        </logger>
+    </springProfile>
+
+</configuration>

--- a/backend/pcloud-batch/src/test/java/com/batch/PCloudBatchServerTest.java
+++ b/backend/pcloud-batch/src/test/java/com/batch/PCloudBatchServerTest.java
@@ -1,0 +1,12 @@
+package com.batch;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class PCloudBatchServerTest {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/backend/pcloud-batch/src/test/java/com/batch/helper/IntegrationHelper.java
+++ b/backend/pcloud-batch/src/test/java/com/batch/helper/IntegrationHelper.java
@@ -1,0 +1,43 @@
+package com.batch.helper;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.util.List;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class IntegrationHelper extends AbstractTestExecutionListener {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void init() {
+        RestAssured.port = this.port;
+        validateH2Database();
+        List<String> truncateAllTablesQuery = jdbcTemplate.queryForList("SELECT CONCAT('TRUNCATE TABLE ', TABLE_NAME, ';') AS q FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC'", String.class);
+        truncateAllTables(truncateAllTablesQuery);
+    }
+
+    private void validateH2Database() {
+        jdbcTemplate.queryForObject("SELECT H2VERSION() FROM DUAL", String.class);
+    }
+
+    private void truncateAllTables(List<String> truncateAllTablesQuery) {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        for (String truncateQuery : truncateAllTablesQuery) {
+            jdbcTemplate.execute(truncateQuery);
+        }
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+}

--- a/backend/pcloud-batch/src/test/resources/application.yml
+++ b/backend/pcloud-batch/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  profiles:
+    include:
+      - domain
+      - common
+      - infrastructure
+    active: test

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/LikedPopups.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/LikedPopups.java
@@ -1,0 +1,40 @@
+package com.domain.domains.popups.domain;
+
+import com.domain.domains.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@EqualsAndHashCode(of = "id", callSuper = false)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class LikedPopups extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long popupsId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    public static LikedPopups of(final Long popupsId, final Long memberId) {
+        return LikedPopups.builder()
+                .popupsId(popupsId)
+                .memberId(memberId)
+                .build();
+    }
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/Popups.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/Popups.java
@@ -116,7 +116,7 @@ public class Popups extends BaseEntity {
         this.statistic.addVisitedCount();
     }
 
-    public void addLikedCount() {
-        this.statistic.addLikedCount();
+    public void addLikedCount(final boolean canAdd) {
+        this.statistic.addLikedCount(canAdd);
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/Popups.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/Popups.java
@@ -7,6 +7,7 @@ import com.domain.domains.common.PublicTag;
 import com.domain.domains.popups.domain.vo.AvailableTime;
 import com.domain.domains.popups.domain.vo.Latitude;
 import com.domain.domains.popups.domain.vo.Longitude;
+import com.domain.domains.popups.domain.vo.Statistic;
 import com.domain.domains.popups.domain.vo.StoreDetails;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -54,6 +55,9 @@ public class Popups extends BaseEntity {
     @Embedded
     private Longitude longitude;
 
+    @Embedded
+    private Statistic statistic;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PublicTag publicTag;
@@ -89,6 +93,7 @@ public class Popups extends BaseEntity {
                 .latitude(Latitude.from(latitude))
                 .longitude(Longitude.from(longitude))
                 .publicTag(PublicTag.from(publicTag))
+                .statistic(Statistic.createDefault())
                 .build();
     }
 
@@ -105,5 +110,13 @@ public class Popups extends BaseEntity {
         if (!this.getOwnerId().equals(ownerId)) {
             throw new AuthException(AUTH_NOT_EQUALS_EXCEPTION);
         }
+    }
+
+    public void addViewCount() {
+        this.statistic.addVisitedCount();
+    }
+
+    public void addLikedCount() {
+        this.statistic.addLikedCount();
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/PopupsRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/PopupsRepository.java
@@ -15,4 +15,10 @@ public interface PopupsRepository {
     Optional<PopupsSpecificResponse> findSpecificById(Long id);
 
     List<PopupsSimpleResponse> findAllWithPaging(Long popupsId, Integer pageSize);
+
+    boolean existsByProductIdAndMemberId(Long popupsId, Long memberId);
+
+    void deleteLikedPopupsByPopupsIdAndMemberId(Long popupsId, Long memberId);
+
+    LikedPopups saveLikedPopups(LikedPopups likedPopups);
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/response/PopupsSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/response/PopupsSimpleResponse.java
@@ -7,6 +7,8 @@ public record PopupsSimpleResponse(
         String title,
         String location,
         LocalDateTime startDate,
-        LocalDateTime endDate
+        LocalDateTime endDate,
+        Integer visitedCount,
+        Integer likedCount
 ) {
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/response/PopupsSpecificResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/response/PopupsSpecificResponse.java
@@ -23,6 +23,8 @@ public class PopupsSpecificResponse {
     private final BigDecimal latitude;
     private final BigDecimal longitude;
     private final String publicTag;
+    private final Integer visitedCount;
+    private final Integer likedCount;
     private final List<String> tags;
 
     public PopupsSpecificResponse(
@@ -39,6 +41,8 @@ public class PopupsSpecificResponse {
             final BigDecimal latitude,
             final BigDecimal longitude,
             final PublicTag publicTag,
+            final Integer visitedCount,
+            final Integer likedCount,
             final List<CustomTagSimpleResponse> tags
     ) {
         this.id = id;
@@ -54,6 +58,8 @@ public class PopupsSpecificResponse {
         this.latitude = latitude;
         this.longitude = longitude;
         this.publicTag = publicTag.getName();
+        this.visitedCount = visitedCount;
+        this.likedCount = likedCount;
         this.tags = tags.stream()
                 .map(CustomTagSimpleResponse::name)
                 .toList();

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/vo/Statistic.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/vo/Statistic.java
@@ -1,0 +1,40 @@
+package com.domain.domains.popups.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Embeddable
+public class Statistic {
+
+    private static final int DEFAULT_STATISTIC_COUNT = 0;
+
+    @Column(nullable = false)
+    private Integer visitedCount;
+
+    @Column(nullable = false)
+    private Integer likedCount;
+
+    public static Statistic createDefault() {
+        return Statistic.builder()
+                .visitedCount(DEFAULT_STATISTIC_COUNT)
+                .likedCount(DEFAULT_STATISTIC_COUNT)
+                .build();
+    }
+
+    public void addVisitedCount() {
+        this.visitedCount++;
+    }
+
+    public void addLikedCount() {
+        this.likedCount++;
+    }
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/vo/Statistic.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/domain/vo/Statistic.java
@@ -34,7 +34,12 @@ public class Statistic {
         this.visitedCount++;
     }
 
-    public void addLikedCount() {
-        this.likedCount++;
+    public void addLikedCount(final boolean canAdd) {
+        if (canAdd) {
+            this.likedCount++;
+            return;
+        }
+
+        this.likedCount--;
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/infrastructure/LikedPopupsJpaRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/infrastructure/LikedPopupsJpaRepository.java
@@ -1,0 +1,16 @@
+package com.domain.domains.popups.infrastructure;
+
+import com.domain.domains.popups.domain.LikedPopups;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LikedPopupsJpaRepository extends JpaRepository<LikedPopups, Long> {
+
+    @Query("SELECT CASE WHEN COUNT(lp) > 0 THEN true ELSE false END FROM LikedPopups lp WHERE lp.popupsId = :popupsId AND lp.memberId = :memberId")
+    boolean existsByPopupsIdAndMemberId(@Param("popupsId") Long popupsId, @Param("memberId") Long memberId);
+
+    void deleteByPopupsIdAndMemberId(Long popupsId, Long memberId);
+
+    LikedPopups save(LikedPopups likedPopups);
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/domains/popups/infrastructure/PopupsQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/domains/popups/infrastructure/PopupsQueryRepository.java
@@ -45,6 +45,8 @@ public class PopupsQueryRepository {
                                 popups.latitude.value,
                                 popups.longitude.value,
                                 popups.publicTag,
+                                popups.statistic.visitedCount,
+                                popups.statistic.likedCount,
                                 list(constructor(CustomTagSimpleResponse.class,
                                         customTag.name
                                 )))
@@ -64,7 +66,9 @@ public class PopupsQueryRepository {
                         popups.storeDetails.title,
                         popups.storeDetails.location,
                         popups.availableTime.startDate,
-                        popups.availableTime.endDate
+                        popups.availableTime.endDate,
+                        popups.statistic.visitedCount,
+                        popups.statistic.likedCount
                 )).from(popups)
                 .where(ltPopupsId(popupsId))
                 .orderBy(popups.id.desc())

--- a/backend/pcloud-domain/src/test/java/com/domain/domains/popups/domain/vo/StatisticTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/domains/popups/domain/vo/StatisticTest.java
@@ -2,6 +2,7 @@ package com.domain.domains.popups.domain.vo;
 
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,16 +24,33 @@ class StatisticTest {
         assertThat(statistic.getVisitedCount()).isEqualTo(defaultCount + 1);
     }
 
-    @Test
-    void 좋아요_수를_증가한다() {
-        // given
-        Statistic statistic = Statistic.createDefault();
-        Integer defaultCount = statistic.getLikedCount();
+    @Nested
+    class 좋아요_수_테스트 {
 
-        // when
-        statistic.addLikedCount();
+        @Test
+        void 좋아요_수를_증가한다() {
+            // given
+            Statistic statistic = Statistic.createDefault();
+            Integer defaultCount = statistic.getLikedCount();
 
-        // then
-        assertThat(statistic.getLikedCount()).isEqualTo(defaultCount + 1);
+            // when
+            statistic.addLikedCount(true);
+
+            // then
+            assertThat(statistic.getLikedCount()).isEqualTo(defaultCount + 1);
+        }
+
+        @Test
+        void 좋아요_수를_감소시킨다() {
+            // given
+            Statistic statistic = Statistic.createDefault();
+            Integer defaultCount = statistic.getLikedCount();
+
+            // when
+            statistic.addLikedCount(false);
+
+            // then
+            assertThat(statistic.getLikedCount()).isEqualTo(defaultCount - 1);
+        }
     }
 }

--- a/backend/pcloud-domain/src/test/java/com/domain/domains/popups/domain/vo/StatisticTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/domains/popups/domain/vo/StatisticTest.java
@@ -1,0 +1,38 @@
+package com.domain.domains.popups.domain.vo;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class StatisticTest {
+
+    @Test
+    void 방문자_수를_증가한다() {
+        // given
+        Statistic statistic = Statistic.createDefault();
+        Integer defaultCount = statistic.getVisitedCount();
+
+        // when
+        statistic.addVisitedCount();
+
+        // then
+        assertThat(statistic.getVisitedCount()).isEqualTo(defaultCount + 1);
+    }
+
+    @Test
+    void 좋아요_수를_증가한다() {
+        // given
+        Statistic statistic = Statistic.createDefault();
+        Integer defaultCount = statistic.getLikedCount();
+
+        // when
+        statistic.addLikedCount();
+
+        // then
+        assertThat(statistic.getLikedCount()).isEqualTo(defaultCount + 1);
+    }
+}

--- a/backend/pcloud-domain/src/test/java/com/domain/domains/popups/infrastructure/LikedPopupsJpaRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/domains/popups/infrastructure/LikedPopupsJpaRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.domain.domains.popups.infrastructure;
+
+import com.domain.domains.popups.domain.LikedPopups;
+import com.domain.helper.IntegrationHelper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static popups.fixture.LikedPopupsFixture.팝업_좋아요_생성_팝업_아이디_1_멤버_아이디_1;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class LikedPopupsJpaRepositoryTest extends IntegrationHelper {
+
+    @Autowired
+    private LikedPopupsJpaRepository likedPopupsJpaRepository;
+
+    @Test
+    void 팝업_좋아요를_저장한다() {
+        // given
+        LikedPopups likedPopups = 팝업_좋아요_생성_팝업_아이디_1_멤버_아이디_1();
+
+        // when
+        LikedPopups savedLikedPopups = likedPopupsJpaRepository.save(likedPopups);
+
+        // then
+        assertThat(savedLikedPopups.getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 팝업_좋아요가_존재하면_true를_반환한다() {
+        // given
+        LikedPopups likedPopups = likedPopupsJpaRepository.save(팝업_좋아요_생성_팝업_아이디_1_멤버_아이디_1());
+
+        // when
+        boolean result = likedPopupsJpaRepository.existsByPopupsIdAndMemberId(likedPopups.getId(), likedPopups.getMemberId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 팝업_좋아요를_제거한다() {
+        // given
+        LikedPopups savedLikedPopups = likedPopupsJpaRepository.save(팝업_좋아요_생성_팝업_아이디_1_멤버_아이디_1());
+
+        // when
+        likedPopupsJpaRepository.deleteByPopupsIdAndMemberId(savedLikedPopups.getPopupsId(), savedLikedPopups.getMemberId());
+
+        // then
+        Optional<LikedPopups> result = likedPopupsJpaRepository.findById(savedLikedPopups.getId());
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/pcloud-domain/src/test/java/com/domain/domains/popups/infrastructure/PopupsQueryRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/domains/popups/infrastructure/PopupsQueryRepositoryTest.java
@@ -8,6 +8,7 @@ import com.domain.domains.popups.domain.response.PopupsSpecificResponse;
 import com.domain.domains.popups.domain.vo.AvailableTime;
 import com.domain.domains.popups.domain.vo.Latitude;
 import com.domain.domains.popups.domain.vo.Longitude;
+import com.domain.domains.popups.domain.vo.Statistic;
 import com.domain.domains.popups.domain.vo.StoreDetails;
 import com.domain.helper.IntegrationHelper;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -72,6 +73,7 @@ class PopupsQueryRepositoryTest extends IntegrationHelper {
                             ).latitude(Latitude.from("34"))
                             .longitude(Longitude.from("128"))
                             .publicTag(PublicTag.PET)
+                            .statistic(Statistic.createDefault())
                             .build()
             );
         }
@@ -112,6 +114,7 @@ class PopupsQueryRepositoryTest extends IntegrationHelper {
                             ).latitude(Latitude.from("34"))
                             .longitude(Longitude.from("128"))
                             .publicTag(PublicTag.PET)
+                            .statistic(Statistic.createDefault())
                             .build()
             );
         }

--- a/backend/pcloud-domain/src/testFixtures/java/popups/FakePopupsRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/popups/FakePopupsRepository.java
@@ -1,5 +1,6 @@
 package popups;
 
+import com.domain.domains.popups.domain.LikedPopups;
 import com.domain.domains.popups.domain.Popups;
 import com.domain.domains.popups.domain.PopupsRepository;
 import com.domain.domains.popups.domain.response.CustomTagSimpleResponse;
@@ -14,20 +15,22 @@ import java.util.Optional;
 
 public class FakePopupsRepository implements PopupsRepository {
 
-    private final Map<Long, Popups> map = new HashMap<>();
-    private Long id = 0L;
+    private final Map<Long, LikedPopups> likedPopupsDB = new HashMap<>();
+    private final Map<Long, Popups> popupsDB = new HashMap<>();
+    private Long popupsId = 0L;
+    private Long likedPopupsId = 0L;
 
     @Override
     public Optional<Popups> findById(final Long id) {
-        return Optional.ofNullable(map.get(id));
+        return Optional.ofNullable(popupsDB.get(id));
     }
 
     @Override
     public Popups save(final Popups popups) {
-        id++;
+        popupsId++;
 
         Popups savedPopups = Popups.builder()
-                .id(id)
+                .id(popupsId)
                 .ownerId(popups.getOwnerId())
                 .storeDetails(popups.getStoreDetails())
                 .availableTime(popups.getAvailableTime())
@@ -37,17 +40,17 @@ public class FakePopupsRepository implements PopupsRepository {
                 .statistic(popups.getStatistic())
                 .build();
 
-        map.put(id, savedPopups);
+        popupsDB.put(popupsId, savedPopups);
         return savedPopups;
     }
 
     @Override
     public Optional<PopupsSpecificResponse> findSpecificById(final Long id) {
-        if (!map.containsKey(id)) {
+        if (!popupsDB.containsKey(id)) {
             return Optional.empty();
         }
 
-        Popups popups = map.get(id);
+        Popups popups = popupsDB.get(id);
         PopupsSpecificResponse response = new PopupsSpecificResponse(
                 popups.getId(),
                 popups.getOwnerId(),
@@ -83,5 +86,33 @@ public class FakePopupsRepository implements PopupsRepository {
                         0
                 )
         );
+    }
+
+    @Override
+    public boolean existsByProductIdAndMemberId(final Long popupsId, final Long memberId) {
+        return likedPopupsDB.values().stream()
+                .anyMatch(likedPopups -> likedPopups.getPopupsId().equals(popupsId) && likedPopups.getMemberId().equals(memberId));
+    }
+
+    @Override
+    public void deleteLikedPopupsByPopupsIdAndMemberId(final Long popupsId, final Long memberId) {
+        likedPopupsDB.entrySet().stream()
+                .filter(entry -> entry.getValue().getPopupsId().equals(popupsId) && entry.getValue().getMemberId().equals(memberId))
+                .findAny()
+                .ifPresent(longLikedPopupsEntry -> likedPopupsDB.remove(longLikedPopupsEntry.getKey()));
+    }
+
+    @Override
+    public LikedPopups saveLikedPopups(final LikedPopups likedPopups) {
+        LikedPopups savedPopups = LikedPopups.builder()
+                .id(likedPopupsId)
+                .popupsId(likedPopups.getPopupsId())
+                .memberId(likedPopups.getMemberId())
+                .build();
+
+        likedPopupsDB.put(likedPopupsId, savedPopups);
+        likedPopupsId++;
+
+        return savedPopups;
     }
 }

--- a/backend/pcloud-domain/src/testFixtures/java/popups/FakePopupsRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/popups/FakePopupsRepository.java
@@ -34,6 +34,7 @@ public class FakePopupsRepository implements PopupsRepository {
                 .latitude(popups.getLatitude())
                 .longitude(popups.getLongitude())
                 .publicTag(popups.getPublicTag())
+                .statistic(popups.getStatistic())
                 .build();
 
         map.put(id, savedPopups);
@@ -61,6 +62,8 @@ public class FakePopupsRepository implements PopupsRepository {
                 popups.getLatitude().getValue(),
                 popups.getLongitude().getValue(),
                 popups.getPublicTag(),
+                popups.getStatistic().getVisitedCount(),
+                popups.getStatistic().getLikedCount(),
                 List.of(new CustomTagSimpleResponse("빵빵이"))
         );
 
@@ -75,7 +78,9 @@ public class FakePopupsRepository implements PopupsRepository {
                         "빵빵이 전시회",
                         "서울시 마포구",
                         LocalDateTime.now().minusDays(100),
-                        LocalDateTime.now()
+                        LocalDateTime.now(),
+                        0,
+                        0
                 )
         );
     }

--- a/backend/pcloud-domain/src/testFixtures/java/popups/fixture/LikedPopupsFixture.java
+++ b/backend/pcloud-domain/src/testFixtures/java/popups/fixture/LikedPopupsFixture.java
@@ -1,0 +1,10 @@
+package popups.fixture;
+
+import com.domain.domains.popups.domain.LikedPopups;
+
+public class LikedPopupsFixture {
+
+    public static LikedPopups 팝업_좋아요_생성_팝업_아이디_1_멤버_아이디_1() {
+        return LikedPopups.of(1L, 1L);
+    }
+}

--- a/backend/pcloud-domain/src/testFixtures/java/popups/fixture/PopupsFixture.java
+++ b/backend/pcloud-domain/src/testFixtures/java/popups/fixture/PopupsFixture.java
@@ -6,6 +6,7 @@ import com.domain.domains.popups.domain.Popups;
 import com.domain.domains.popups.domain.vo.AvailableTime;
 import com.domain.domains.popups.domain.vo.Latitude;
 import com.domain.domains.popups.domain.vo.Longitude;
+import com.domain.domains.popups.domain.vo.Statistic;
 import com.domain.domains.popups.domain.vo.StoreDetails;
 
 import java.time.LocalDateTime;
@@ -32,6 +33,7 @@ public class PopupsFixture {
                 ).latitude(Latitude.from("34"))
                 .longitude(Longitude.from("128"))
                 .publicTag(PublicTag.PET)
+                .statistic(Statistic.createDefault())
                 .build();
     }
 
@@ -55,6 +57,7 @@ public class PopupsFixture {
                 ).latitude(Latitude.from("34"))
                 .longitude(Longitude.from("128"))
                 .publicTag(PublicTag.BEAUTY)
+                .statistic(Statistic.createDefault())
                 .build();
     }
 
@@ -78,6 +81,7 @@ public class PopupsFixture {
                 ).latitude(Latitude.from("34"))
                 .longitude(Longitude.from("128"))
                 .publicTag(PublicTag.BEAUTY)
+                .statistic(Statistic.createDefault())
                 .build();
     }
 }

--- a/backend/pcloud-domain/src/testFixtures/java/popups/fixture/PopupsSpecificResponseFixture.java
+++ b/backend/pcloud-domain/src/testFixtures/java/popups/fixture/PopupsSpecificResponseFixture.java
@@ -30,6 +30,8 @@ public class PopupsSpecificResponseFixture {
                 Latitude.from("37.556725").getValue(),
                 Longitude.from("126.9234952").getValue(),
                 PublicTag.CHARACTER,
+                0,
+                0,
                 List.of(new CustomTagSimpleResponse("빵빵이"))
         );
     }

--- a/backend/pcloud-infrastructure/build.gradle
+++ b/backend/pcloud-infrastructure/build.gradle
@@ -3,6 +3,9 @@ jar { enabled = true }
 
 dependencies {
     implementation project(':pcloud-common')
-    testImplementation(testFixtures(project(":pcloud-domain")))
+
+    // redis
+    api 'org.springframework.boot:spring-boot-starter-data-redis'
+
     testImplementation(testFixtures(project(":pcloud-common")))
 }

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisCacheConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisCacheConfig.java
@@ -1,0 +1,36 @@
+package com.infra.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager contentCacheManager(final RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair
+                        .fromSerializer(new StringRedisSerializer())
+                ).serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer())
+                ).entryTtl(makeRedisCacheRemainingTime());
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    }
+
+    private static Duration makeRedisCacheRemainingTime() {
+        return Duration.ofHours(1L);
+    }
+}

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.infra.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -22,9 +23,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
-        return redisTemplate;
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
     }
 }

--- a/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-local.yml
+++ b/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-local.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-prod.yml
+++ b/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-prod.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-test.yml
+++ b/backend/pcloud-infrastructure/src/main/resources/application-infrastructure-test.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/backend/pcloud-infrastructure/src/test/resources/application.yml
+++ b/backend/pcloud-infrastructure/src/test/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -3,4 +3,5 @@ include 'pcloud-common'
 include 'pcloud-domain'
 include 'pcloud-infrastructure'
 include 'pcloud-api'
+include 'pcloud-batch'
 


### PR DESCRIPTION
## 📄 Summary

LikedPopups 테이블에 관해서 회의는 16일에 진행했습니다.
회의에서 나눈 대화에 맞게 추후 통계 기능에서 사용되기 때문에 별도의 관심사로 분리합니다.
현재 PR에서는 분리를 유연하게 할 수 있도록 구현하였습니다.

- 팝업 스토어의 좋아요 및 방문자 기능을 추가했습니다.
  - 방문자 처리 처리는 #15 이슈에서 진행 예정입니다.
  - 동시성 관련된 처리는 추후 회의를 통해 어떻게 할지 결정하고 https://github.com/sosow0212/2024-pop-cloud/issues/16 이슈에서 진행합니다.
 
- Batch 모듈을 생성 및 기본 설정 추가
- infrastructure모듈에 Redis 설정 추가 (추후 사용에 따라 config 변경 필요)



close #14