### PR TITLE
feat: Popups, Recommend의 캐싱 작업 및 배치 스케줄러 추가

### DIFF
--- a/backend/pcloud-api/docs/asciidoc/recommends.adoc
+++ b/backend/pcloud-api/docs/asciidoc/recommends.adoc
@@ -9,10 +9,10 @@
 
 === Request
 
-include::{snippets}/recommend-controller-test/find_popularity_shows/query-parameters.adoc[]
-include::{snippets}/recommend-controller-test/find_popularity_shows/http-request.adoc[]
+include::{snippets}/recommend-controller-web-mvc-test/find_popularity_shows/query-parameters.adoc[]
+include::{snippets}/recommend-controller-web-mvc-test/find_popularity_shows/http-request.adoc[]
 
 === Response
 
-include::{snippets}/recommend-controller-test/find_popularity_shows/response-fields.adoc[]
-include::{snippets}/recommend-controller-test/find_popularity_shows/http-response.adoc[]
+include::{snippets}/recommend-controller-web-mvc-test/find_popularity_shows/response-fields.adoc[]
+include::{snippets}/recommend-controller-web-mvc-test/find_popularity_shows/http-response.adoc[]

--- a/backend/pcloud-api/src/main/java/com/api/global/config/moduleutils/ComponentScanConfig.java
+++ b/backend/pcloud-api/src/main/java/com/api/global/config/moduleutils/ComponentScanConfig.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(value = {"com.common", "com.domain", "com.infrastructure"})
+@ComponentScan(value = {"com.common", "com.domain", "com.infra"})
 public class ComponentScanConfig {
 }

--- a/backend/pcloud-api/src/main/java/com/api/global/config/moduleutils/ComponentScanConfig.java
+++ b/backend/pcloud-api/src/main/java/com/api/global/config/moduleutils/ComponentScanConfig.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ComponentScan(value = {"com.common", "com.domain", "com.infra"})
+@ComponentScan(value = {"com.common", "com.domain", "com.infrastructure"})
 public class ComponentScanConfig {
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/common/annotation/ClientIpFinder.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/common/annotation/ClientIpFinder.java
@@ -1,0 +1,11 @@
+package com.api.show.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ClientIpFinder {
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/common/config/ShowCommonHandlerMethodArgumentResolverConfig.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/common/config/ShowCommonHandlerMethodArgumentResolverConfig.java
@@ -1,0 +1,21 @@
+package com.api.show.common.config;
+
+import com.api.show.common.resolver.ClientIpFinderResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class ShowCommonHandlerMethodArgumentResolverConfig implements WebMvcConfigurer {
+
+    private final ClientIpFinderResolver clientIpFinderResolver;
+
+    @Override
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(clientIpFinderResolver);
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/common/resolver/ClientIpFinderResolver.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/common/resolver/ClientIpFinderResolver.java
@@ -1,0 +1,52 @@
+package com.api.show.common.resolver;
+
+import com.api.show.common.annotation.ClientIpFinder;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.List;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Component
+public class ClientIpFinderResolver implements HandlerMethodArgumentResolver {
+
+    private static final List<String> IP_HEADER_TYPES = List.of(
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_X_FORWARDED_FOR"
+    );
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(ClientIpFinder.class) &&
+                parameter.getParameterType().equals(String.class);
+    }
+
+    @Override
+    public String resolveArgument(
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+        return findClientIp(httpServletRequest);
+    }
+
+    private String findClientIp(final HttpServletRequest request) {
+        return IP_HEADER_TYPES.stream()
+                .map(request::getHeader)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseGet(request::getRemoteAddr);
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
@@ -21,8 +21,8 @@ public class PopupsQueryService {
 
     private final PopupsRepository popupsRepository;
 
-    public PopupsSpecificResponse findById(final Long popupsId) {
-        Events.raise(new PopupsFoundEvent(popupsId));
+    public PopupsSpecificResponse findById(final Long popupsId, final String clientIp) {
+        Events.raise(new PopupsFoundEvent(popupsId, clientIp));
         return popupsRepository.findSpecificById(popupsId)
                 .orElseThrow(() -> new PopupsException(POPUPS_NOT_FOUND_EXCEPTION));
     }

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 public class PopupsCacheRepositoryImpl implements PopupsCacheRepository {
 
     private static final String CACHE_PREFIX = "popups:";
+    private static final String IP_PREFIX = ":ip";
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -20,7 +21,7 @@ public class PopupsCacheRepositoryImpl implements PopupsCacheRepository {
     }
 
     private String makePopupsIdWithIpKeyName(final Long popupsId) {
-        return CACHE_PREFIX + popupsId + ":ip";
+        return CACHE_PREFIX + popupsId + IP_PREFIX;
     }
 
     @Override

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.api.show.popups.infrastructure;
+
+import com.domain.show.popups.cache.PopupsCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class PopupsCacheRepositoryImpl implements PopupsCacheRepository {
+
+    private static final String CACHE_PREFIX = "popups:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void cachePopupsIdWithIp(final Long popupsId, final String ip) {
+        String key = makePopupsIdWithIpKeyName(popupsId);
+        redisTemplate.opsForSet().add(key, ip);
+    }
+
+    private String makePopupsIdWithIpKeyName(final Long popupsId) {
+        return CACHE_PREFIX + popupsId + ":ip";
+    }
+
+    @Override
+    public boolean isPopupsIdAlreadyCachedWithIp(final Long popupsId, final String ip) {
+        String key = makePopupsIdWithIpKeyName(popupsId);
+        return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, ip));
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/presentation/PopupsController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/presentation/PopupsController.java
@@ -1,5 +1,6 @@
 package com.api.show.popups.presentation;
 
+import com.api.show.common.annotation.ClientIpFinder;
 import com.api.show.popups.application.PopupsQueryService;
 import com.api.show.popups.application.PopupsService;
 import com.api.show.popups.application.request.PopupsCreateRequest;
@@ -55,12 +56,12 @@ public class PopupsController {
         return ResponseEntity.ok(popupsQueryService.findAll(popupsId, pageSize));
     }
 
-    /**
-     * TODO : 조회시 방문자 수 처리하기 (#14 Issue 이후 작업)
-     */
     @GetMapping("/{popupsId}")
-    public ResponseEntity<PopupsSpecificResponse> findById(@PathVariable final Long popupsId) {
-        return ResponseEntity.ok(popupsQueryService.findById(popupsId));
+    public ResponseEntity<PopupsSpecificResponse> findById(
+            @PathVariable final Long popupsId,
+            @ClientIpFinder final String clientIp
+    ) {
+        return ResponseEntity.ok(popupsQueryService.findById(popupsId, clientIp));
     }
 
     @PatchMapping("/{popupsId}")

--- a/backend/pcloud-api/src/main/java/com/api/show/recommend/application/RecommendService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/recommend/application/RecommendService.java
@@ -6,6 +6,7 @@ import com.domain.show.recommend.domain.Recommend;
 import com.domain.show.recommend.domain.RecommendRepository;
 import com.domain.show.recommend.domain.Recommends;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +20,8 @@ public class RecommendService {
     private final PopularityCalculator popularityCalculator;
 
     @Transactional(readOnly = true)
-    public List<Recommend> findPopularShowsWithinDateRange(final DateSearchRequest dateSearchRequest) {
+    @Cacheable(cacheNames = "popularShowsCache", key = "#dateSearchRequest.toString()", cacheManager = "contentCacheManager")
+    public Recommends findPopularShowsWithinDateRange(final DateSearchRequest dateSearchRequest) {
         List<Recommend> foundRecommend = recommendRepository.findAllFromStartDateToEndDateWithLimitByShowTypes(
                 dateSearchRequest.startDate(),
                 dateSearchRequest.endDate(),

--- a/backend/pcloud-api/src/main/java/com/api/show/recommend/infrastructure/RecommendQueryRepository.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/recommend/infrastructure/RecommendQueryRepository.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,28 +22,25 @@ public class RecommendQueryRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     public List<Recommend> findAllFromStartDateToEndDateWithLimitByShowTypes(
-            final LocalDateTime startDate,
-            final LocalDateTime endDate,
+            final LocalDateTime startTime,
+            final LocalDateTime endTime,
             final List<ShowType> showTypes
     ) {
         List<Recommend> result = new ArrayList<>();
 
-        LocalDateTime startDateMinTime = startDate.toLocalDate().atTime(LocalTime.MIN);
-        LocalDateTime endDateMaxTime = endDate.toLocalDate().atTime(LocalTime.MAX);
-
         if (showTypes.contains(ShowType.ALL)) {
-            result.addAll(getPopups(startDateMinTime, endDateMaxTime));
-            result.addAll(getExhibition(startDateMinTime, endDateMaxTime));
+            result.addAll(getPopups(startTime, endTime));
+            result.addAll(getExhibition(startTime, endTime));
             return result;
         }
 
         for (ShowType showType : showTypes) {
             if (showType.equals(ShowType.POPUPS)) {
-                result.addAll(getPopups(startDateMinTime, endDateMaxTime));
+                result.addAll(getPopups(startTime, endTime));
             }
 
             if (showType.equals(ShowType.EXHIBITION)) {
-                result.addAll(getExhibition(startDateMinTime, endDateMaxTime));
+                result.addAll(getExhibition(startTime, endTime));
             }
         }
 

--- a/backend/pcloud-api/src/main/java/com/api/show/recommend/infrastructure/RecommendRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/recommend/infrastructure/RecommendRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.api.show.recommend.infrastructure;
 import com.domain.show.common.ShowType;
 import com.domain.show.recommend.domain.Recommend;
 import com.domain.show.recommend.domain.RecommendRepository;
+import com.domain.show.recommend.infrastructure.RecommendQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/backend/pcloud-api/src/main/java/com/api/show/recommend/presentation/RecommendController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/recommend/presentation/RecommendController.java
@@ -3,7 +3,7 @@ package com.api.show.recommend.presentation;
 import com.api.show.popups.application.request.DateSearchRequest;
 import com.api.show.recommend.application.RecommendService;
 import com.api.show.recommend.presentation.annotation.PopularShowRequest;
-import com.domain.show.recommend.domain.Recommend;
+import com.domain.show.recommend.domain.Recommends;
 import com.domain.show.recommend.domain.dto.RecommendSimpleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +22,7 @@ public class RecommendController {
 
     @GetMapping("/popularity")
     public ResponseEntity<List<RecommendSimpleResponse>> findPopularShowsWithinDateRange(@PopularShowRequest final DateSearchRequest dateSearchRequest) {
-        List<Recommend> recommends = recommendService.findPopularShowsWithinDateRange(dateSearchRequest);
+        Recommends recommends = recommendService.findPopularShowsWithinDateRange(dateSearchRequest);
         return ResponseEntity.ok(RecommendSimpleResponse.from(recommends));
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/recommend/presentation/resolver/PopularShowRequestArgumentResolver.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/recommend/presentation/resolver/PopularShowRequestArgumentResolver.java
@@ -13,6 +13,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
@@ -51,8 +52,10 @@ public class PopularShowRequestArgumentResolver implements HandlerMethodArgument
         int limit = PopularShowRequestHelper.parseLimit(limitParam);
         List<ShowType> showTypes = PopularShowRequestHelper.findShowTypes(targetParam);
 
-        LocalDateTime startDate = PopularShowRequestHelper.parseLocalDateTime(startDateParam, formatter);
-        LocalDateTime endDate = PopularShowRequestHelper.parseLocalDateTime(endDateParam, formatter);
+        LocalDateTime startDate = PopularShowRequestHelper.parseLocalDateTime(startDateParam, formatter)
+                .toLocalDate().atTime(LocalTime.MIN);
+        LocalDateTime endDate = PopularShowRequestHelper.parseLocalDateTime(endDateParam, formatter)
+                .toLocalDate().atTime(LocalTime.MAX);
         PopularShowRequestHelper.validateDateRange(startDate, endDate);
 
         return new DateSearchRequest(limit, startDate, endDate, showTypes);

--- a/backend/pcloud-api/src/test/java/com/api/helper/MockBeanInjection.java
+++ b/backend/pcloud-api/src/test/java/com/api/helper/MockBeanInjection.java
@@ -3,6 +3,7 @@ package com.api.helper;
 import com.api.auth.application.AuthService;
 import com.api.global.aop.OptimisticLockRetryAspect;
 import com.api.global.config.interceptor.auth.support.AuthenticationContext;
+import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.exhibition.application.ExhibitionQueryService;
 import com.api.show.exhibition.application.ExhibitionService;
 import com.api.show.popups.application.PopupsQueryService;
@@ -22,6 +23,9 @@ public class MockBeanInjection {
 
     @MockBean
     protected AuthenticationContext authenticationContext;
+
+    @MockBean
+    protected ClientIpFinderResolver clientIpFinderResolver;
 
     @MockBean
     protected OptimisticLockRetryAspect optimisticLockRetryAspect;

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/application/PopupsServiceConcurrencyTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/application/PopupsServiceConcurrencyTest.java
@@ -33,7 +33,7 @@ class PopupsServiceConcurrencyTest extends IntegrationHelper {
     //    @Test
     void 좋아요_동시성_테스트_동기처리() throws InterruptedException {
         // given
-        PopupsFoundEvent event = new PopupsFoundEvent(popups.getId());
+        PopupsFoundEvent event = new PopupsFoundEvent(popups.getId(), "");
         int requestCount = 15;
 
         // when

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
@@ -1,14 +1,12 @@
 package com.api.show.popups.presentation;
 
 import com.api.helper.MockBeanInjection;
+import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.popups.application.request.PopupsCreateRequest;
 import com.api.show.popups.application.request.PopupsUpdateRequest;
 import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -18,12 +16,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 import static com.api.helper.RestDocsHelper.customDocument;
 import static com.api.show.popups.fixture.request.PopupsRequestFixtures.팝업스토어_생성_요청;
 import static com.api.show.popups.fixture.request.PopupsRequestFixtures.팝업스토어_업데이트_요청;
 import static member.fixture.MemberFixture.어드민_멤버_생성_id_없음_kakao_oauth_가입;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -54,6 +57,8 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
 
     @Autowired
     private ObjectMapper objectMapper;
+    @Autowired
+    private ClientIpFinderResolver clientIpFinderResolver;
 
     @Test
     void 팝업스토어를_생성한다() throws Exception {
@@ -128,7 +133,9 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
     void 팝업스토어_상세조회를_한다() throws Exception {
         // given
         PopupsSpecificResponse response = 팝업스토어_상세_조회_응답_생성();
-        when(popupsQueryService.findById(anyLong())).thenReturn(response);
+        when(popupsQueryService.findById(anyLong(), anyString())).thenReturn(response);
+        when(clientIpFinderResolver.supportsParameter(any())).thenReturn(true);
+        when(clientIpFinderResolver.resolveArgument(any(), any(), any(), any())).thenReturn("123.11.1.1");
 
         // when
         mockMvc.perform(get("/popups/{popupsId}", 1)
@@ -142,18 +149,18 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("ownerId").description("팝업스토어 게시글 작성자 id"),
                                 fieldWithPath("title").description("팝업스토어 이름"),
                                 fieldWithPath("description").description("팝업스토어 설명"),
+                                fieldWithPath("startDate").description("팝업스토어 시작일"),
+                                fieldWithPath("endDate").description("팝업스토어 종료일"),
+                                fieldWithPath("openTimes").description("팝업스토어 운영 시간"),
                                 fieldWithPath("location").description("팝업스토어 장소명"),
+                                fieldWithPath("latitude").description("위도"),
+                                fieldWithPath("longitude").description("경도"),
                                 fieldWithPath("isParkingAvailable").description("주차 가능 여부"),
                                 fieldWithPath("isFoodAllowed").description("식음료 반입 여부"),
                                 fieldWithPath("isPetAllowed").description("반려 동물 출입 가능 여부"),
                                 fieldWithPath("isKidsZone").description("키즈존 유무"),
                                 fieldWithPath("isWifiAvailable").description("와이파이 사용가능 여부"),
                                 fieldWithPath("fee").description("팝업스토어 입장요금"),
-                                fieldWithPath("startDate").description("팝업스토어 시작일"),
-                                fieldWithPath("endDate").description("팝업스토어 종료일"),
-                                fieldWithPath("openTimes").description("팝업스토어 운영 시간"),
-                                fieldWithPath("latitude").description("위도"),
-                                fieldWithPath("longitude").description("경도"),
                                 fieldWithPath("publicTag").description("공용 퍼블릭 태그"),
                                 fieldWithPath("visitedCount").description("팝업스토어 게시글 방문자 수"),
                                 fieldWithPath("likedCount").description("팝업스토어 게시글 좋아요 수"),

--- a/backend/pcloud-api/src/test/java/com/api/show/recommend/application/RecommendServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/recommend/application/RecommendServiceTest.java
@@ -50,7 +50,7 @@ class RecommendServiceTest {
                 .thenReturn(expect);
 
         // when
-        List<Recommend> response = recommendService.findPopularShowsWithinDateRange(request);
+        List<Recommend> response = recommendService.findPopularShowsWithinDateRange(request).getRecommends();
 
         // then
         assertSoftly(softly -> {

--- a/backend/pcloud-api/src/test/java/com/api/show/recommend/infrastructure/RecommendQueryRepositoryTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/recommend/infrastructure/RecommendQueryRepositoryTest.java
@@ -7,6 +7,7 @@ import com.domain.show.exhibition.domain.ExhibitionRepository;
 import com.domain.show.popups.domain.Popups;
 import com.domain.show.popups.domain.PopupsRepository;
 import com.domain.show.recommend.domain.Recommend;
+import com.domain.show.recommend.infrastructure.RecommendQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;

--- a/backend/pcloud-api/src/test/java/com/api/show/recommend/presentation/RecommendControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/recommend/presentation/RecommendControllerWebMvcTest.java
@@ -3,6 +3,7 @@ package com.api.show.recommend.presentation;
 import com.api.helper.MockBeanInjection;
 import com.api.show.popups.application.request.DateSearchRequest;
 import com.domain.show.common.ShowType;
+import com.domain.show.recommend.domain.Recommends;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -42,13 +43,13 @@ class RecommendControllerWebMvcTest extends MockBeanInjection {
         when(popularShowRequestArgumentResolver.supportsParameter(any())).thenReturn(true);
         when(popularShowRequestArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(mockRequest);
         when(recommendService.findPopularShowsWithinDateRange(any())).thenReturn(
-                List.of(
+                Recommends.from(List.of(
                         추천_생성_전시회타입_조회수_좋아요_사용(29, 55),
                         추천_생성_팝업타입_조회수_좋아요_사용(21, 40),
                         추천_생성_팝업타입_조회수_좋아요_사용(19, 30),
                         추천_생성_팝업타입_조회수_좋아요_사용(15, 20),
                         추천_생성_팝업타입_조회수_좋아요_사용(10, 10)
-                )
+                ))
         );
 
         // when & then

--- a/backend/pcloud-api/src/test/java/com/api/show/recommend/presentation/RecommendControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/recommend/presentation/RecommendControllerWebMvcTest.java
@@ -66,13 +66,12 @@ class RecommendControllerWebMvcTest extends MockBeanInjection {
                                 parameterWithName("target").description("쇼케이스 타입 (all, popups, exhibition) updated 24.08.29")
                         ),
                         responseFields(
-                                fieldWithPath("[].id").description("팝업스토어 id"),
-                                fieldWithPath("[].title").description("팝업스토어 이름"),
-                                fieldWithPath("[].location").description("팝업스토어 장소명"),
-                                fieldWithPath("[].startDate").description("팝업스토어 시작일"),
-                                fieldWithPath("[].endDate").description("팝업스토어 종료일"),
-                                fieldWithPath("[].visitedCount").description("팝업스토어 게시글 방문자 수"),
-                                fieldWithPath("[].likedCount").description("팝업스토어 게시글 좋아요 수")
+                                fieldWithPath("[].id").description("특정 쇼케이스 id"),
+                                fieldWithPath("[].showType").description("쇼케이스 종류"),
+                                fieldWithPath("[].title").description("쇼케이스 이름"),
+                                fieldWithPath("[].location").description("쇼케이스 장소명"),
+                                fieldWithPath("[].startDate").description("쇼케이스 시작일"),
+                                fieldWithPath("[].endDate").description("쇼케이스 종료일")
                         )
                 ));
     }

--- a/backend/pcloud-batch/src/main/java/com/batch/annotation/BatchPublisher.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/annotation/BatchPublisher.java
@@ -1,0 +1,21 @@
+package com.batch.annotation;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface BatchPublisher {
+    @AliasFor(
+            annotation = Component.class
+    )
+    String value() default "";
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/annotation/BatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/annotation/BatchService.java
@@ -1,0 +1,22 @@
+package com.batch.annotation;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface BatchService {
+    @AliasFor(
+            annotation = Component.class
+    )
+    String value() default "";
+}
+

--- a/backend/pcloud-batch/src/main/java/com/batch/global/common/event/BatchEvent.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/common/event/BatchEvent.java
@@ -1,0 +1,13 @@
+package com.batch.global.common.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class BatchEvent {
+
+    private final LocalDateTime eventTime;
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/AsyncConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.batch.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(5);
+        executor.setQueueCapacity(500);
+        executor.setMaxPoolSize(15);
+        executor.setKeepAliveSeconds(30);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+
+        return executor;
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/RestTemplateConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/RestTemplateConfig.java
@@ -1,4 +1,4 @@
-package com.batch.config;
+package com.batch.global.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/ScheduleConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package com.batch.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class ScheduleConfig {
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/SlackAppender.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/SlackAppender.java
@@ -1,4 +1,4 @@
-package com.batch.config;
+package com.batch.global.config;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/ComponentScanConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/ComponentScanConfig.java
@@ -1,4 +1,4 @@
-package com.batch.config.moduleutils;
+package com.batch.global.config.moduleutils;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/PropertySourceScanConfig.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/PropertySourceScanConfig.java
@@ -1,4 +1,4 @@
-package com.batch.config.moduleutils;
+package com.batch.global.config.moduleutils;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;

--- a/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/YamlPropertySourceFactory.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/global/config/moduleutils/YamlPropertySourceFactory.java
@@ -1,4 +1,4 @@
-package com.batch.config.moduleutils;
+package com.batch.global.config.moduleutils;
 
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.core.env.PropertiesPropertySource;

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchPublisher.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchPublisher.java
@@ -1,0 +1,22 @@
+package com.batch.job.show.popups.application;
+
+import com.batch.annotation.BatchPublisher;
+import com.batch.job.show.popups.application.event.ClearedIpEvent;
+import com.common.config.event.Events;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@BatchPublisher
+public class PopupsBatchPublisher {
+
+    private static final String EVERY_FIVE_AM = "0 0 5 * * *";
+
+    @Scheduled(cron = EVERY_FIVE_AM)
+    public void clearPopupIpCache() {
+        Events.raise(new ClearedIpEvent(LocalDateTime.now()));
+        log.info("배치 작업 완료");
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchService.java
@@ -1,0 +1,9 @@
+package com.batch.job.show.popups.application;
+
+import com.batch.annotation.BatchService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@BatchService
+public class PopupsBatchService {
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/PopupsBatchService.java
@@ -1,9 +1,22 @@
 package com.batch.job.show.popups.application;
 
 import com.batch.annotation.BatchService;
+import com.batch.job.show.popups.application.event.ClearedIpEvent;
+import com.batch.job.show.popups.domain.PopupsCacheBatchRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 
+@Slf4j
 @RequiredArgsConstructor
 @BatchService
 public class PopupsBatchService {
+
+    private final PopupsCacheBatchRepository popupsCacheBatchRepository;
+
+    @EventListener(ClearedIpEvent.class)
+    public void clearPopupsIpCache(final ClearedIpEvent event) {
+        log.info("start job: {}, startTime: {} ", "clearPopupsIpCache", event.getEventTime());
+        popupsCacheBatchRepository.clearIpCache();
+    }
 }

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/event/ClearedIpEvent.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/application/event/ClearedIpEvent.java
@@ -1,0 +1,14 @@
+package com.batch.job.show.popups.application.event;
+
+import com.batch.global.common.event.BatchEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ClearedIpEvent extends BatchEvent {
+
+    public ClearedIpEvent(final LocalDateTime eventTime) {
+        super(eventTime);
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/domain/PopupsCacheBatchRepository.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/domain/PopupsCacheBatchRepository.java
@@ -1,0 +1,6 @@
+package com.batch.job.show.popups.domain;
+
+public interface PopupsCacheBatchRepository {
+
+    void clearIpCache();
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/infrastructure/PopupsCacheBatchRepositoryImpl.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/popups/infrastructure/PopupsCacheBatchRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.batch.job.show.popups.infrastructure;
+
+import com.batch.job.show.popups.domain.PopupsCacheBatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Repository;
+
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Repository
+public class PopupsCacheBatchRepositoryImpl implements PopupsCacheBatchRepository {
+
+    private static final String CACHE_PREFIX_PATTERN = "popups:*:ip";
+    private static final int SCAN_COUNT = 1000;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void clearIpCache() {
+        ScanOptions scanOption = ScanOptions.scanOptions()
+                .count(SCAN_COUNT)
+                .match(CACHE_PREFIX_PATTERN)
+                .build();
+
+        Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .scan(scanOption);
+
+        while (cursor.hasNext()) {
+            byte[] next = cursor.next();
+            String key = new String(next, StandardCharsets.UTF_8);
+            redisTemplate.delete(key);
+        }
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchPublisher.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchPublisher.java
@@ -1,0 +1,22 @@
+package com.batch.job.show.recommend.application;
+
+import com.batch.annotation.BatchPublisher;
+import com.batch.job.show.recommend.application.event.ClearedRecommendEvent;
+import com.common.config.event.Events;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@BatchPublisher
+public class RecommendBatchPublisher {
+
+    private static final String EVERY_SIX_AM = "0 0 6 * * *";
+
+    @Scheduled(cron = EVERY_SIX_AM)
+    public void clearRecommendCache() {
+        Events.raise(new ClearedRecommendEvent(LocalDateTime.now()));
+        log.info("배치 작업 완료");
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchService.java
@@ -1,9 +1,22 @@
 package com.batch.job.show.recommend.application;
 
 import com.batch.annotation.BatchService;
+import com.batch.job.show.recommend.application.event.ClearedRecommendEvent;
+import com.batch.job.show.recommend.domain.RecommendCacheBatchRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 
+@Slf4j
 @RequiredArgsConstructor
 @BatchService
 public class RecommendBatchService {
+
+    private final RecommendCacheBatchRepository recommendCacheBatchRepository;
+
+    @EventListener(ClearedRecommendEvent.class)
+    public void clearRecommendCache(final ClearedRecommendEvent event) {
+        log.info("start job: {}, startTime: {} ", "resetRecommendCache", event.getEventTime());
+        recommendCacheBatchRepository.clearRecommendCache();
+    }
 }

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/RecommendBatchService.java
@@ -1,0 +1,9 @@
+package com.batch.job.show.recommend.application;
+
+import com.batch.annotation.BatchService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@BatchService
+public class RecommendBatchService {
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/event/ClearedRecommendEvent.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/application/event/ClearedRecommendEvent.java
@@ -1,0 +1,14 @@
+package com.batch.job.show.recommend.application.event;
+
+import com.batch.global.common.event.BatchEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ClearedRecommendEvent extends BatchEvent {
+
+    public ClearedRecommendEvent(final LocalDateTime eventTime) {
+        super(eventTime);
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/domain/RecommendCacheBatchRepository.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/domain/RecommendCacheBatchRepository.java
@@ -1,0 +1,6 @@
+package com.batch.job.show.recommend.domain;
+
+public interface RecommendCacheBatchRepository {
+
+    void clearRecommendCache();
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/infrastructure/RecommendCacheBatchRepositoryImpl.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/recommend/infrastructure/RecommendCacheBatchRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.batch.job.show.recommend.infrastructure;
+
+import com.batch.job.show.recommend.domain.RecommendCacheBatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Repository;
+
+import java.nio.charset.StandardCharsets;
+
+@RequiredArgsConstructor
+@Repository
+public class RecommendCacheBatchRepositoryImpl implements RecommendCacheBatchRepository {
+
+    private static final String CACHE_PREFIX_PATTERN = "popularShowsCache::*";
+    private static final int SCAN_COUNT = 1000;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void clearRecommendCache() {
+        ScanOptions scanOption = ScanOptions.scanOptions()
+                .count(SCAN_COUNT)
+                .match(CACHE_PREFIX_PATTERN)
+                .build();
+
+        Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .scan(scanOption);
+
+        while (cursor.hasNext()) {
+            byte[] next = cursor.next();
+            String key = new String(next, StandardCharsets.UTF_8);
+            redisTemplate.delete(key);
+        }
+    }
+}

--- a/backend/pcloud-batch/src/main/resources/logback-spring.xml
+++ b/backend/pcloud-batch/src/main/resources/logback-spring.xml
@@ -11,7 +11,7 @@
         <appender-ref ref="CONSOLE"/>
     </root>
 
-    <appender name="SLACK_APPENDER" class="com.batch.config.SlackAppender">
+    <appender name="SLACK_APPENDER" class="com.batch.global.config.SlackAppender">
     </appender>
 
     <appender name="ASYNC_SLACK_APPENDER" class="ch.qos.logback.classic.AsyncAppender">

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/cache/PopupsCacheRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/cache/PopupsCacheRepository.java
@@ -1,0 +1,8 @@
+package com.domain.show.popups.cache;
+
+public interface PopupsCacheRepository {
+
+    boolean isPopupsIdAlreadyCachedWithIp(Long popupsId, String ip);
+
+    void cachePopupsIdWithIp(Long popupsId, String ip);
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/event/PopupsFoundEvent.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/event/PopupsFoundEvent.java
@@ -1,6 +1,7 @@
 package com.domain.show.popups.event;
 
 public record PopupsFoundEvent(
-        Long popupsId
+        Long popupsId,
+        String clientIp
 ) {
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/Recommend.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/Recommend.java
@@ -5,18 +5,21 @@ import com.domain.show.common.ShowSchedule;
 import com.domain.show.common.ShowType;
 import com.domain.show.common.Statistic;
 import com.domain.show.popups.domain.service.PopularityCalculator;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recommend {
 
-    private final Long id;
-    private final ShowType showType;
-    private final ShowDetails showDetails;
-    private final ShowSchedule showSchedule;
-    private final Statistic statistics;
+    private Long id;
+    private ShowType showType;
+    private ShowDetails showDetails;
+    private ShowSchedule showSchedule;
+    private Statistic statistics;
 
     public double calculatePopularScore(final PopularityCalculator calculator) {
         return this.statistics.calculatePopularScore(calculator);

--- a/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/Recommends.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/Recommends.java
@@ -3,24 +3,28 @@ package com.domain.show.recommend.domain;
 import com.domain.show.popups.domain.service.PopularityCalculator;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Comparator;
 import java.util.List;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recommends {
 
-    private final List<Recommend> recommends;
+    private List<Recommend> recommends;
 
     public static Recommends from(final List<Recommend> recommends) {
         return new Recommends(recommends);
     }
 
-    public List<Recommend> findPopularityShows(final PopularityCalculator popularityCalculator, final int limit) {
-        return recommends.stream()
+    public Recommends findPopularityShows(final PopularityCalculator popularityCalculator, final int limit) {
+        return new Recommends(recommends.stream()
                 .sorted(makeReverseOrder(popularityCalculator))
                 .limit(limit)
-                .toList();
+                .toList());
     }
 
     private Comparator<Recommend> makeReverseOrder(final PopularityCalculator popularityCalculator) {

--- a/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/dto/RecommendSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/dto/RecommendSimpleResponse.java
@@ -1,5 +1,6 @@
 package com.domain.show.recommend.domain.dto;
 
+import com.domain.show.common.ShowType;
 import com.domain.show.recommend.domain.Recommend;
 
 import java.time.LocalDateTime;
@@ -7,24 +8,22 @@ import java.util.List;
 
 public record RecommendSimpleResponse(
         Long id,
+        ShowType showType,
         String title,
         String location,
         LocalDateTime startDate,
-        LocalDateTime endDate,
-        Integer visitedCount,
-        Integer likedCount
+        LocalDateTime endDate
 ) {
 
     public static List<RecommendSimpleResponse> from(final List<Recommend> recommends) {
         return recommends.stream()
                 .map(recommend -> new RecommendSimpleResponse(
                         recommend.getId(),
+                        recommend.getShowType(),
                         recommend.getShowDetails().getTitle(),
                         recommend.getShowDetails().getDescription(),
                         recommend.getShowSchedule().getStartDate(),
-                        recommend.getShowSchedule().getEndDate(),
-                        recommend.getStatistics().getVisitedCount(),
-                        recommend.getStatistics().getLikedCount()
+                        recommend.getShowSchedule().getEndDate()
                 )).toList();
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/dto/RecommendSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/recommend/domain/dto/RecommendSimpleResponse.java
@@ -1,7 +1,7 @@
 package com.domain.show.recommend.domain.dto;
 
 import com.domain.show.common.ShowType;
-import com.domain.show.recommend.domain.Recommend;
+import com.domain.show.recommend.domain.Recommends;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,8 +15,8 @@ public record RecommendSimpleResponse(
         LocalDateTime endDate
 ) {
 
-    public static List<RecommendSimpleResponse> from(final List<Recommend> recommends) {
-        return recommends.stream()
+    public static List<RecommendSimpleResponse> from(final Recommends recommends) {
+        return recommends.getRecommends().stream()
                 .map(recommend -> new RecommendSimpleResponse(
                         recommend.getId(),
                         recommend.getShowType(),

--- a/backend/pcloud-domain/src/main/java/com/domain/show/recommend/infrastructure/RecommendQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/recommend/infrastructure/RecommendQueryRepository.java
@@ -1,4 +1,4 @@
-package com.api.show.recommend.infrastructure;
+package com.domain.show.recommend.infrastructure;
 
 import com.domain.show.common.ShowType;
 import com.domain.show.recommend.domain.Recommend;

--- a/backend/pcloud-domain/src/test/java/com/domain/show/recommend/domain/RecommendsTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/show/recommend/domain/RecommendsTest.java
@@ -30,7 +30,7 @@ class RecommendsTest {
         Recommends recommends = Recommends.from(List.of(popupRecommend1, popupRecommend2, popupRecommend3, popupRecommend4, popupRecommend5));
 
         // when
-        List<Recommend> result = recommends.findPopularityShows(fakePopularityCalculator, limit);
+        List<Recommend> result = recommends.findPopularityShows(fakePopularityCalculator, limit).getRecommends();
 
         // then
         assertSoftly(softly -> {

--- a/backend/pcloud-infrastructure/build.gradle
+++ b/backend/pcloud-infrastructure/build.gradle
@@ -7,5 +7,9 @@ dependencies {
     // redis
     api 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.2'
+
     testImplementation(testFixtures(project(":pcloud-common")))
 }

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisCacheConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisCacheConfig.java
@@ -1,5 +1,9 @@
 package com.infra.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -12,25 +16,56 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @EnableCaching
 @Configuration
 public class RedisCacheConfig {
 
+    private static final long HOUR = 1L;
+    private static final long DAY = 24L;
+
     @Bean
-    public CacheManager contentCacheManager(final RedisConnectionFactory connectionFactory) {
-        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+    public CacheManager contentCacheManager(final RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheDefault = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext
                         .SerializationPair
                         .fromSerializer(new StringRedisSerializer())
                 ).serializeValuesWith(RedisSerializationContext.SerializationPair
-                        .fromSerializer(new GenericJackson2JsonRedisSerializer())
-                ).entryTtl(makeRedisCacheRemainingTime());
+                        .fromSerializer(getGenericJackson2JsonRedisSerializer())
+                ).entryTtl(makeCacheTTLByHour(HOUR));
 
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
+        Map<String, RedisCacheConfiguration> configurations = makeConfigurations(cacheDefault);
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(cacheDefault)
+                .withInitialCacheConfigurations(configurations)
+                .build();
     }
 
-    private static Duration makeRedisCacheRemainingTime() {
-        return Duration.ofHours(1L);
+    private GenericJackson2JsonRedisSerializer getGenericJackson2JsonRedisSerializer() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        return new GenericJackson2JsonRedisSerializer(objectMapper);
+    }
+
+    private Duration makeCacheTTLByHour(final Long hour) {
+        return Duration.ofHours(hour);
+    }
+
+    private Map<String, RedisCacheConfiguration> makeConfigurations(final RedisCacheConfiguration cacheDefault) {
+        Map<String, RedisCacheConfiguration> configurations = new HashMap<>();
+        configurations.put("popularShowsCache", cacheDefault.entryTtl(makeCacheTTLByHour(DAY)));
+        return configurations;
     }
 }

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
@@ -1,11 +1,17 @@
 package com.infra.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -19,15 +25,27 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(final RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, String> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        return template;
+    public RedisTemplate<?, ?> redisTemplate(final RedisConnectionFactory redisConnectionFactory) {
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
+                .builder()
+                .allowIfSubType(Object.class)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+        GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(redisSerializer);
+
+        return redisTemplate;
     }
 }

--- a/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infra/config/RedisConfig.java
@@ -23,7 +23,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    public RedisTemplate<String, String> redisTemplate(final RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());

--- a/backend/pcloud-infrastructure/src/main/java/com/infrastructure/PCloudInfraApplication.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infrastructure/PCloudInfraApplication.java
@@ -1,4 +1,4 @@
-package com.infra;
+package com.infrastructure;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisCacheConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisCacheConfig.java
@@ -1,4 +1,4 @@
-package com.infra.config;
+package com.infrastructure.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.infra.config;
+package com.infrastructure.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;

--- a/backend/pcloud-infrastructure/src/test/java/com/infra/study/redis/RedisTemplateTest.java
+++ b/backend/pcloud-infrastructure/src/test/java/com/infra/study/redis/RedisTemplateTest.java
@@ -1,0 +1,29 @@
+package com.infra.study.redis;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class RedisTemplateTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    //    @Test
+    void 레디스_키_저장() {
+        // given
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String key = "stringKey";
+
+        // when
+        valueOperations.set(key, "hello");
+
+        // then
+        String value = valueOperations.get(key);
+        assertThat(value).isEqualTo("hello");
+    }
+}

--- a/backend/pcloud-infrastructure/src/test/java/com/infrastructure/PCloudInfraApplicationTest.java
+++ b/backend/pcloud-infrastructure/src/test/java/com/infrastructure/PCloudInfraApplicationTest.java
@@ -1,4 +1,4 @@
-package com.infra;
+package com.infrastructure;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/backend/pcloud-infrastructure/src/test/java/com/infrastructure/study/redis/RedisTemplateTest.java
+++ b/backend/pcloud-infrastructure/src/test/java/com/infrastructure/study/redis/RedisTemplateTest.java
@@ -1,4 +1,4 @@
-package com.infra.study.redis;
+package com.infrastructure.study.redis;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 📄 Summary

- [1. PR 내용 요약](#1-pr-내용-요약)
- [2. 기술 사용 근거 및 고민한 지점에 대해서](#2-기술-사용-근거-및-고민한-지점에-대해서)
  - [2-1. Redis 사용 이유](#2-1-redis-사용-이유)
  - [2-2. Redis 고민 지점 (캐시 스탬피드 및 정합성)](#2-2-redis-고민-지점-캐시-스탬피드-및-정합성)
  - [2-3. batch 스케줄러](#2-3-batch-스케줄러)
- [3. 인기 쇼케이스 조회 API 성능 개선](#3-인기-쇼케이스-조회-api-성능-개선)
  - [3-1. 성능 테스트 환경](#3-1-성능-테스트-환경)
  - [3-2. Ver1. 캐싱 사용 전 TPS](#3-2-ver1-캐싱-사용-전-tps)
  - [3-3. Ver2. 캐싱 사용 후 TPS](#3-3-ver2-캐싱-사용-후-tps)
  - [3-4. 결론](#3-4-결론)
- [4. 작업 내용](#4-작업-내용)

---

## 2. 기술 사용 근거 및 고민한 지점에 대해서
### 2-1. Redis 사용 이유
- dev 환경이고, 단일 서버로 돌아가는 현재 상황에서는 Redis 캐싱은 굳이 필요 없습니다. 하지만 배포시 스케일아웃을 고려하고 있기 때문에 이를 염두하여 Redis를 사용하였습니다. 애그리거트 별로 사용되는 RedisCacheRepository를 인터페이스로 만들고 DI를 통해 실제 구현체를 주입시키고 있으므로 추후에도 Redis가 불필요하다면 캐싱 구현체를 In-memory인 ConcurrentMap과 같은 자료구조를 활용해 구현하셔도 됩니다.

### 2-2. Redis 고민 지점 (캐시 스탬피드 및 정합성)
Redis는 배치 스케줄러가 돌아가지 않는 경우를 대비하여 기본 TTL은 설정해주었지만 batch를 통해 주기적인 시간에 초기화 됩니다.
작업 범위 한에서 캐싱 데이터가 초기화가 되고난 이후 `캐시 스탬피드`가 일어나지 않을까 고민을 했습니다.

이에 대한 결과는, `날짜를 기준으로 조회하는 추천 쇼케이스 (Recommend)`에 캐싱되는 내용을 고민했을 때 쉽게 해결할 수 있었습니다.
먼저 `추천 쇼케이스` 같은 경우는 프론트 단에서 `8월의 추천 쇼케이스`와 같은 랜딩 페이지에서 조회하는 API입니다. 즉 클라이언트 단에서 넘어오는 `요청 param은 모두 동일합니다.` 따라서 캐싱 데이터에 많은 데이터가 들어오지 않아 캐싱 스탬피드를 고민할 필요가 없습니다.

이 부분은 추후 생기는 batch 작업에서 더 다뤄보면 좋을 것 같습니다.
,
정합성에 관한 부분입니다. 예를 들어 `8월의 인기 쇼케이스`를 기준으로 하루동안 순위 밖에 있던 쇼케이스가 인기가 높아져 `인기 점수`가 높아진다면 TTL 기간 혹은 스케줄러 작동 구간동안은 정합성이 보장되지 않습니다.
다만 현재 구조로는 이를 해결할 수가 없고, TTL과 스케줄러 주기를 하루로 짧게 잡았으므로 큰 이슈는 없을 거라 생각합니다.


### 2-3. batch 스케줄러
현재 batch 스케줄러는 다중 환경에서 스케줄 작업이 중복으로 실행됩니다.
이 부분은 너무 길어질 것 같아 다음 작업으로 분리했습니다. https://github.com/sosow0212/2024-pop-cloud/issues/27

## 3. 인기 쇼케이스 조회 API 성능 개선

### 3-1. 성능 테스트 환경
- 성능 테스트 도구로 JMeter를 선택하였습니다.
- 2,000 건의 Popups, Exhibition 데이터를 이용했습니다.
- 예상 사용자인 500명의 사용자가 10초 동안 요청을 보내는 경우를 테스트 했습니다.
- 배포 이전이라 로컬 환경에서 테스트 했습니다. (스테이징 환경에서는 달라질 수 있는 결과입니다.)

### 3-2. Ver1. 캐싱 사용 전 TPS
- 최고 처리 기준 약 600 TPS

### 3-3. Ver2. 캐싱 사용 후 TPS
- 최고 처리 기준 약 3000 TPS

### 3-4. 결론
- Redis 캐싱을 이용하고 인기 쇼케이스 조회 성능은 기존 대비 5배 향상했습니다.
- 추가적으로 캐싱할 때 index를 걸어 조회한다면 첫 조회가 더 빨라질 수 있지만 이는 나중에 인덱스 설정을 할 때 더 다뤄보면 좋을 것 같습니다.

## 4. 작업 내용
- [x] 인기 쇼케이스 반환시 showType 누락된 거 추가 및 조회수, 좋아요 컬럼 제거
- [x] 주간 or 날짜 기준 인기 쇼케이스 캐싱
- [x] 조회수 치팅을 방지한 ip 레디스 캐싱
- [x] 위 두 가지 기능을 초기화 시켜주는 배치 작업을 추가한다

## 🙋🏻 More

>
