### PR TITLE
feat: exhibition의 캐싱 작업과 배치 작업을 진행한다

### DIFF
--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionEventHandler.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionEventHandler.java
@@ -1,0 +1,44 @@
+package com.api.show.exhibition.application;
+
+import com.domain.annotation.RetryOptimisticLock;
+import com.domain.show.exhibition.cache.ExhibitionCacheRepository;
+import com.domain.show.exhibition.domain.Exhibition;
+import com.domain.show.exhibition.domain.ExhibitionRepository;
+import com.domain.show.exhibition.event.ExhibitionFoundEvent;
+import com.domain.show.exhibition.exception.ExhibitionException;
+import com.domain.show.exhibition.exception.ExhibitionExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Service
+public class ExhibitionEventHandler {
+
+    private final ExhibitionRepository exhibitionRepository;
+    private final ExhibitionCacheRepository exhibitionCacheRepository;
+
+    @Async
+    @RetryOptimisticLock
+    @TransactionalEventListener(value = ExhibitionFoundEvent.class, phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void addViewCount(final ExhibitionFoundEvent event) {
+        String ip = event.clientIp();
+        Long exhibitionId = event.exhibitionId();
+
+        if (exhibitionCacheRepository.isExhibitionIdWithIpNotCached(exhibitionId, ip)) {
+            Exhibition foundExhibition = findExhibitionWithOptimisticLock(exhibitionId);
+            exhibitionCacheRepository.cacheExhibitionIdWithIp(exhibitionId, ip);
+            foundExhibition.addViewCount();
+        }
+    }
+
+    private Exhibition findExhibitionWithOptimisticLock(final Long exhibitionId) {
+        return exhibitionRepository.findByIdWithOptimisticLock(exhibitionId)
+                .orElseThrow(() -> new ExhibitionException(ExhibitionExceptionType.EXHIBITION_NOT_FOUND_EXCEPTION));
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionQueryService.java
@@ -1,8 +1,10 @@
 package com.api.show.exhibition.application;
 
+import com.common.config.event.Events;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
 import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
+import com.domain.show.exhibition.event.ExhibitionFoundEvent;
 import com.domain.show.exhibition.exception.ExhibitionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +21,8 @@ public class ExhibitionQueryService {
 
     private final ExhibitionRepository exhibitionRepository;
 
-    public ExhibitionSpecificResponse findById(final Long exhibitionId) {
+    public ExhibitionSpecificResponse findById(final Long exhibitionId, final String clientIp) {
+        Events.raise(new ExhibitionFoundEvent(exhibitionId, clientIp));
         return exhibitionRepository.findSpecificById(exhibitionId)
                 .orElseThrow(() -> new ExhibitionException(EXHIBITION_NOT_FOUND_EXCEPTION));
     }

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/infrastructure/ExhibitionCacheRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/infrastructure/ExhibitionCacheRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.api.show.exhibition.infrastructure;
+
+import com.domain.show.exhibition.cache.ExhibitionCacheRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ExhibitionCacheRepositoryImpl implements ExhibitionCacheRepository {
+
+    private static final String CACHE_PREFIX = "exhibition:";
+    private static final String CACHE_SUFFIX = ":ip";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+
+    @Override
+    public void cacheExhibitionIdWithIp(final Long exhibitionId, final String ip) {
+        String key = makeExhibitionIdWithIpKeyName(exhibitionId);
+        redisTemplate.opsForSet().add(key, ip);
+    }
+
+    private String makeExhibitionIdWithIpKeyName(final Long exhibitionId) {
+        return CACHE_PREFIX + exhibitionId + CACHE_SUFFIX;
+    }
+
+    @Override
+    public boolean isExhibitionIdWithIpNotCached(final Long exhibitionId, final String ip) {
+        String key = makeExhibitionIdWithIpKeyName(exhibitionId);
+        return Boolean.FALSE.equals(redisTemplate.opsForSet().isMember(key, ip));
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/infrastructure/ExhibitionCacheRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/infrastructure/ExhibitionCacheRepositoryImpl.java
@@ -14,7 +14,6 @@ public class ExhibitionCacheRepositoryImpl implements ExhibitionCacheRepository 
 
     private final RedisTemplate<String, String> redisTemplate;
 
-
     @Override
     public void cacheExhibitionIdWithIp(final Long exhibitionId, final String ip) {
         String key = makeExhibitionIdWithIpKeyName(exhibitionId);

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
@@ -1,5 +1,6 @@
 package com.api.show.exhibition.presentation;
 
+import com.api.show.common.annotation.ClientIpFinder;
 import com.api.show.exhibition.application.ExhibitionQueryService;
 import com.api.show.exhibition.application.ExhibitionService;
 import com.api.show.exhibition.application.dto.ExhibitionCreateRequest;
@@ -54,8 +55,10 @@ public class ExhibitionController {
      * TODO: 조회 시 방문자 수 처리 (추후에 유스케이스 적용)
      */
     @GetMapping("/{exhibitionId}")
-    public ResponseEntity<ExhibitionSpecificResponse> findById(@PathVariable final Long exhibitionId) {
-        return ResponseEntity.ok(exhibitionQueryService.findById(exhibitionId));
+    public ResponseEntity<ExhibitionSpecificResponse> findById(
+            @PathVariable final Long exhibitionId,
+            @ClientIpFinder final String clientIp) {
+        return ResponseEntity.ok(exhibitionQueryService.findById(exhibitionId, clientIp));
     }
 
     @GetMapping

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/application/ExhibitionQueryServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/application/ExhibitionQueryServiceTest.java
@@ -39,9 +39,10 @@ class ExhibitionQueryServiceTest {
         // given
         Exhibition savedExhibition = exhibitionRepository.save(개인전시회_생성_사진_개인전());
         Long exhibitionId = savedExhibition.getId();
+        String clientIp = "clientIp";
 
         // when
-        ExhibitionSpecificResponse response = exhibitionQueryService.findById(exhibitionId);
+        ExhibitionSpecificResponse response = exhibitionQueryService.findById(exhibitionId, clientIp);
 
         // then
         ExhibitionSpecificResponse expectedResponse = 개인전시회_상세_조회_응답_생성_개인전시회(savedExhibition);

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
@@ -1,5 +1,6 @@
 package com.api.show.exhibition.presentation;
 
+import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.exhibition.application.dto.ExhibitionCreateRequest;
 import com.api.show.exhibition.application.dto.ExhibitionUpdateRequest;
 import com.api.helper.MockBeanInjection;
@@ -18,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인전시회_생성_요청_생성;
 import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인전시회_업데이트_요청_생성;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static show.exhibition.domain.ExhibitionSimpleResponseFixture.개인전시회_간단_조회_응답_생성;
 import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성;
 import static com.api.helper.RestDocsHelper.customDocument;
@@ -51,6 +54,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class ExhibitionControllerWebMvcTest extends MockBeanInjection {
 
     private static final String BEARER_TOKEN = "Bearer tokenInfo ~~";
+
+    @Autowired
+    private ClientIpFinderResolver clientIpFinderResolver;
 
     @Autowired
     private MockMvc mockMvc;
@@ -103,7 +109,9 @@ class ExhibitionControllerWebMvcTest extends MockBeanInjection {
     void 개인전시회를_상세_조회한다() throws Exception {
         // given
         ExhibitionSpecificResponse response = 개인전시회_상세_조회_응답_생성();
-        when(exhibitionQueryService.findById(anyLong())).thenReturn(response);
+        when(exhibitionQueryService.findById(anyLong(), anyString())).thenReturn(response);
+        when(clientIpFinderResolver.supportsParameter(any())).thenReturn(true);
+        when(clientIpFinderResolver.resolveArgument(any(), any(), any(), any())).thenReturn("123.11.1.1");
 
         // when & then
         mockMvc.perform(get("/exhibitions/{exhibitionId}", 1L)

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/ExhibitionBatchPublisher.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/ExhibitionBatchPublisher.java
@@ -1,0 +1,21 @@
+package com.batch.job.show.exhibition.application;
+
+import com.batch.annotation.BatchPublisher;
+import com.batch.job.show.exhibition.application.event.ClearedExhibitionIpEvent;
+import com.common.config.event.Events;
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@BatchPublisher
+public class ExhibitionBatchPublisher {
+
+    private static final String EVERY_FIVE_AM = "0 0 5 * * *";
+
+    @Scheduled(cron = EVERY_FIVE_AM)
+    public void clearExhibitionIpCache() {
+        Events.raise(new ClearedExhibitionIpEvent(LocalDateTime.now()));
+        log.info("배치 작업 완료");
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/ExhibitionBatchService.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/ExhibitionBatchService.java
@@ -1,0 +1,22 @@
+package com.batch.job.show.exhibition.application;
+
+import com.batch.annotation.BatchService;
+import com.batch.job.show.exhibition.application.event.ClearedExhibitionIpEvent;
+import com.batch.job.show.exhibition.domain.ExhibitionCacheBatchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@BatchService
+public class ExhibitionBatchService {
+
+    private final ExhibitionCacheBatchRepository exhibitionCacheBatchRepository;
+
+    @EventListener(ClearedExhibitionIpEvent.class)
+    public void clearExhibitionIpCache(final ClearedExhibitionIpEvent event) {
+        log.info("start job: {}, startTime : {} ", "clearExhibitionIpCache", event.getEventTime());
+        exhibitionCacheBatchRepository.clearIpCache();
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/event/ClearedExhibitionIpEvent.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/application/event/ClearedExhibitionIpEvent.java
@@ -1,0 +1,13 @@
+package com.batch.job.show.exhibition.application.event;
+
+import com.batch.global.common.event.BatchEvent;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ClearedExhibitionIpEvent extends BatchEvent {
+
+    public ClearedExhibitionIpEvent(final LocalDateTime eventTime) {
+        super(eventTime);
+    }
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/domain/ExhibitionCacheBatchRepository.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/domain/ExhibitionCacheBatchRepository.java
@@ -1,0 +1,6 @@
+package com.batch.job.show.exhibition.domain;
+
+public interface ExhibitionCacheBatchRepository {
+
+    void clearIpCache();
+}

--- a/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/infrasturcture/ExhibitionCacheBatchRepositoryImpl.java
+++ b/backend/pcloud-batch/src/main/java/com/batch/job/show/exhibition/infrasturcture/ExhibitionCacheBatchRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.batch.job.show.exhibition.infrasturcture;
+
+import com.batch.job.show.exhibition.domain.ExhibitionCacheBatchRepository;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class ExhibitionCacheBatchRepositoryImpl implements ExhibitionCacheBatchRepository {
+
+    private static final String CACHE_PREFIX_PATTERN = "exhibition:*:ip";
+    private static final int SCAN_COUNT = 1000;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void clearIpCache() {
+        ScanOptions scanOption = ScanOptions.scanOptions()
+                .count(SCAN_COUNT)
+                .match(CACHE_PREFIX_PATTERN)
+                .build();
+
+        Cursor<byte[]> cursor = redisTemplate.getConnectionFactory()
+                .getConnection()
+                .scan(scanOption);
+
+        while (cursor.hasNext()) {
+            byte[] next = cursor.next();
+            String key = new String(next, StandardCharsets.UTF_8);
+            redisTemplate.delete(key);
+        }
+    }
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/cache/ExhibitionCacheRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/cache/ExhibitionCacheRepository.java
@@ -1,0 +1,8 @@
+package com.domain.show.exhibition.cache;
+
+public interface ExhibitionCacheRepository {
+
+    void cacheExhibitionIdWithIp(Long exhibitionId, String ip);
+
+    boolean isExhibitionIdWithIpNotCached(Long exhibitionId, String ip);
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/Exhibition.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/Exhibition.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -59,6 +60,9 @@ public class Exhibition extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private PublicTag publicTag;
+
+    @Version
+    private Long version;
 
     public static Exhibition of(
             final long memberId,

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/ExhibitionRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/ExhibitionRepository.java
@@ -13,6 +13,8 @@ public interface ExhibitionRepository {
 
     Optional<Exhibition> findById(Long exhibitionId);
 
+    Optional<Exhibition> findByIdWithOptimisticLock(Long exhibitionId);
+
     Optional<ExhibitionSpecificResponse> findSpecificById(Long exhibitionId);
 
     List<ExhibitionSimpleResponse> findAllWithPaging(Long exhibitionId, Integer pageSize);

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/event/ExhibitionFoundEvent.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/event/ExhibitionFoundEvent.java
@@ -1,0 +1,7 @@
+package com.domain.show.exhibition.event;
+
+public record ExhibitionFoundEvent(
+        Long exhibitionId,
+        String clientIp
+) {
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionJpaRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionJpaRepository.java
@@ -1,14 +1,22 @@
 package com.domain.show.exhibition.infrastructure;
 
 import com.domain.show.exhibition.domain.Exhibition;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ExhibitionJpaRepository extends JpaRepository<Exhibition, Long> {
 
     Exhibition save(Exhibition exhibition);
 
     Optional<Exhibition> findById(Long exhibitionId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query(value = "select e from Exhibition e where e.id = :exhibitionId")
+    Optional<Exhibition> findByIdWithOptimisticLock(@Param("exhibitionId") Long exhibitionId);
 
     void deleteById(Long exhibitionId);
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionRepositoryImpl.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionRepositoryImpl.java
@@ -34,6 +34,11 @@ public class ExhibitionRepositoryImpl implements ExhibitionRepository {
     }
 
     @Override
+    public Optional<Exhibition> findByIdWithOptimisticLock(final Long exhibitionId) {
+        return exhibitionJpaRepository.findByIdWithOptimisticLock(exhibitionId);
+    }
+
+    @Override
     public Optional<ExhibitionSpecificResponse> findSpecificById(final Long exhibitionId) {
         return exhibitionQueryRepository.findSpecificById(exhibitionId);
     }

--- a/backend/pcloud-domain/src/testFixtures/java/show/exhibition/infrasturcture/ExhibitionFakeRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/show/exhibition/infrasturcture/ExhibitionFakeRepository.java
@@ -57,6 +57,11 @@ public class ExhibitionFakeRepository implements ExhibitionRepository {
     }
 
     @Override
+    public Optional<Exhibition> findByIdWithOptimisticLock(final Long exhibitionId) {
+        return Optional.ofNullable(exhibitionDB.get(exhibitionId));
+    }
+
+    @Override
     public Optional<ExhibitionSpecificResponse> findSpecificById(final Long exhibitionId) {
         if (!exhibitionDB.containsKey(exhibitionId)) {
             return Optional.empty();


### PR DESCRIPTION
## 📄 Summary

* 개인 전시회 상세 조회 시 클라이언트 IP를 콘텐츠별 Redis Set에 저장해 동일 IP의 반복 조회가 하루에 한 번만 집계되도록 구성했습니다. 저장된 IP는 매일 오전 5시 배치 작업으로 초기화합니다.
* 조회수 갱신을 비동기 이벤트로 분리하고, JPA 낙관적 락과 공통 Retry AOP를 적용해 동시 업데이트 충돌이 발생한 요청을 재시도하도록 구성했습니다.

## 🧪 Test

* 락 전략을 결정하기 위해 팀 공동으로 JMeter에서 가상 사용자 1,000명이 각각 10회 요청하는 총 10,000건의 부하를 재현했습니다.
* 같은 조건에서 비관적 락은 2,380 TPS, 낙관적 락은 2,700 TPS를 기록해 낙관적 락의 처리량이 약 13% 높게 측정되었습니다.




close #25