### PR TITLE
feat: Popups 단건 캐싱 및 Evict와 동시성 문제 발생 해결

### DIFF
--- a/backend/pcloud-api/docs/asciidoc/index.adoc
+++ b/backend/pcloud-api/docs/asciidoc/index.adoc
@@ -1,10 +1,13 @@
 ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
-= e-market
+= pop-cloud
 :doctype: book
 :toc: left
 :source-highlighter: highlightjs
 :sectlinks:
 
 include::auth.adoc[]
+include::exhibition.adoc[]
+include::popups.adoc[]
+include::recommends.adoc[]

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
@@ -50,7 +50,7 @@ public class PopupsQueryService {
         }
     }
 
-    private static boolean canCacheWithoutConcurrency(final LocalDateTime cacheEvictTime, final LocalDateTime startFindTime) {
+    private boolean canCacheWithoutConcurrency(final LocalDateTime cacheEvictTime, final LocalDateTime startFindTime) {
         return cacheEvictTime == null ||
                 cacheEvictTime.isBefore(startFindTime);
     }

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
@@ -42,12 +42,17 @@ public class PopupsQueryService {
     }
 
     private void cachePopupsIfExpiredEvictTtl(final Long popupsId, PopupsSpecificResponse foundPopups) {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime evictTime = popupsCacheRepository.findCacheEvictedTimeById(popupsId);
+        LocalDateTime startFindTime = LocalDateTime.now();
+        LocalDateTime cacheEvictTime = popupsCacheRepository.findCacheEvictedTimeById(popupsId);
 
-        if (evictTime == null || evictTime.isBefore(now)) {
+        if (canCacheWithoutConcurrency(cacheEvictTime, startFindTime)) {
             popupsCacheRepository.cachePopups(popupsId, foundPopups);
         }
+    }
+
+    private static boolean canCacheWithoutConcurrency(final LocalDateTime cacheEvictTime, final LocalDateTime startFindTime) {
+        return cacheEvictTime == null ||
+                cacheEvictTime.isBefore(startFindTime);
     }
 
     public List<PopupsSimpleResponse> findAll(final Long popupsId, final Integer pageSize) {

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsCacheRepositoryImpl.java
@@ -1,18 +1,23 @@
 package com.api.show.popups.infrastructure;
 
 import com.domain.show.popups.cache.PopupsCacheRepository;
+import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Repository
 public class PopupsCacheRepositoryImpl implements PopupsCacheRepository {
 
-    private static final String CACHE_PREFIX = "popups:";
     private static final String IP_PREFIX = ":ip";
+    private static final String CACHE_PREFIX = "popups:";
+    private static final String EVICT_TIME_PREFIX = "popup:evictTime:";
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
     public void cachePopupsIdWithIp(final Long popupsId, final String ip) {
@@ -28,5 +33,36 @@ public class PopupsCacheRepositoryImpl implements PopupsCacheRepository {
     public boolean isPopupsIdAlreadyCachedWithIp(final Long popupsId, final String ip) {
         String key = makePopupsIdWithIpKeyName(popupsId);
         return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, ip));
+    }
+
+    @Override
+    public boolean isPopupCached(final Long popupsId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(CACHE_PREFIX + popupsId));
+    }
+
+    @Override
+    public PopupsSpecificResponse findCacheById(final Long popupsId) {
+        return (PopupsSpecificResponse) redisTemplate.opsForValue()
+                .get(CACHE_PREFIX + popupsId);
+    }
+
+    @Override
+    public void cachePopups(final Long popupsId, final PopupsSpecificResponse popupsSpecificResponse) {
+        redisTemplate.opsForValue()
+                .set(CACHE_PREFIX + popupsId, popupsSpecificResponse, Duration.ofHours(1));
+    }
+
+    @Override
+    public void evictCache(final Long popupsId) {
+        redisTemplate.delete(CACHE_PREFIX + popupsId);
+        redisTemplate.opsForValue()
+                .set(EVICT_TIME_PREFIX + popupsId, LocalDateTime.now());
+        redisTemplate.expire(EVICT_TIME_PREFIX + popupsId, Duration.ofSeconds(10));
+    }
+
+    @Override
+    public LocalDateTime findCacheEvictedTimeById(final Long popupsId) {
+        return (LocalDateTime) redisTemplate.opsForValue()
+                .get(EVICT_TIME_PREFIX + popupsId);
     }
 }

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/application/PopupsServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/application/PopupsServiceTest.java
@@ -3,6 +3,7 @@ package com.api.show.popups.application;
 import com.api.show.popups.application.request.PopupsCreateRequest;
 import com.common.exception.AuthException;
 import com.common.exception.AuthExceptionType;
+import com.domain.show.popups.cache.PopupsCacheRepository;
 import com.domain.show.popups.domain.Popups;
 import com.domain.show.popups.domain.PopupsRepository;
 import com.domain.show.popups.exception.PopupsException;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import show.popups.infrastructure.FakePopupsCacheRepository;
 import show.popups.infrastructure.FakePopupsRepository;
 
 import java.util.Optional;
@@ -30,11 +32,13 @@ class PopupsServiceTest {
 
     private PopupsService popupsService;
     private PopupsRepository popupsRepository;
+    private PopupsCacheRepository popupsCacheRepository;
 
     @BeforeEach
     void setup() {
         popupsRepository = new FakePopupsRepository();
-        popupsService = new PopupsService(popupsRepository);
+        popupsCacheRepository = new FakePopupsCacheRepository();
+        popupsService = new PopupsService(popupsRepository, popupsCacheRepository);
     }
 
     @Test

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/cache/PopupsCacheRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/cache/PopupsCacheRepository.java
@@ -1,8 +1,22 @@
 package com.domain.show.popups.cache;
 
+import com.domain.show.popups.domain.response.PopupsSpecificResponse;
+
+import java.time.LocalDateTime;
+
 public interface PopupsCacheRepository {
 
     boolean isPopupsIdAlreadyCachedWithIp(Long popupsId, String ip);
 
     void cachePopupsIdWithIp(Long popupsId, String ip);
+
+    boolean isPopupCached(Long popupsId);
+
+    PopupsSpecificResponse findCacheById(Long popupsId);
+
+    LocalDateTime findCacheEvictedTimeById(Long popupsId);
+
+    void cachePopups(Long popupsId, PopupsSpecificResponse popupsSpecificResponse);
+
+    void evictCache(Long popupsId);
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/response/PopupsSpecificResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/response/PopupsSpecificResponse.java
@@ -1,6 +1,8 @@
 package com.domain.show.popups.domain.response;
 
 import com.domain.show.common.PublicTag;
+
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,7 +28,7 @@ public record PopupsSpecificResponse(
         Integer visitedCount,
         Integer likedCount,
         List<String> tags
-) {
+) implements Serializable {
 
     public PopupsSpecificResponse(
             Long id,

--- a/backend/pcloud-domain/src/testFixtures/java/show/popups/infrastructure/FakePopupsCacheRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/show/popups/infrastructure/FakePopupsCacheRepository.java
@@ -1,0 +1,54 @@
+package show.popups.infrastructure;
+
+import com.domain.show.popups.cache.PopupsCacheRepository;
+import com.domain.show.popups.domain.response.PopupsSpecificResponse;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakePopupsCacheRepository implements PopupsCacheRepository {
+
+    private static final String IP_PREFIX = ":ip";
+    private static final String CACHE_PREFIX = "popups:";
+    private static final String EVICT_TIME_PREFIX = "popup:evictTime:";
+
+    private final Map<String, Object> popupsCache = new HashMap<>();
+    private final Map<String, Object> ttlCache = new HashMap<>();
+
+    @Override
+    public boolean isPopupsIdAlreadyCachedWithIp(final Long popupsId, final String ip) {
+        return popupsCache.containsKey(CACHE_PREFIX + popupsId + IP_PREFIX);
+    }
+
+    @Override
+    public void cachePopupsIdWithIp(final Long popupsId, final String ip) {
+        popupsCache.put(CACHE_PREFIX + popupsId + IP_PREFIX, ip);
+    }
+
+    @Override
+    public boolean isPopupCached(final Long popupsId) {
+        return popupsCache.containsKey(CACHE_PREFIX + popupsId);
+    }
+
+    @Override
+    public PopupsSpecificResponse findCacheById(final Long popupsId) {
+        return (PopupsSpecificResponse) popupsCache.get(CACHE_PREFIX + popupsId);
+    }
+
+    @Override
+    public LocalDateTime findCacheEvictedTimeById(final Long popupsId) {
+        return (LocalDateTime) ttlCache.get(EVICT_TIME_PREFIX + popupsId);
+    }
+
+    @Override
+    public void cachePopups(final Long popupsId, final PopupsSpecificResponse popupsSpecificResponse) {
+        popupsCache.put(CACHE_PREFIX + popupsId, popupsSpecificResponse);
+    }
+
+    @Override
+    public void evictCache(final Long popupsId) {
+        popupsCache.remove(CACHE_PREFIX + popupsId);
+        ttlCache.put(EVICT_TIME_PREFIX + popupsId, LocalDateTime.now());
+    }
+}

--- a/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisConfig.java
+++ b/backend/pcloud-infrastructure/src/main/java/com/infrastructure/config/RedisConfig.java
@@ -1,9 +1,5 @@
 package com.infrastructure.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -29,23 +25,17 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate(final RedisConnectionFactory redisConnectionFactory) {
-        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
-                .builder()
-                .allowIfSubType(Object.class)
-                .build();
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
-        GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(redisSerializer);
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
 
+        redisTemplate.setValueSerializer(new JdkSerializationRedisSerializer());
+        redisTemplate.setHashValueSerializer(new JdkSerializationRedisSerializer());
+
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
     }
 }


### PR DESCRIPTION
## 📄 Summary

Popups 데이터가 적기 때문에 단건 데이터 조회시 캐싱을 적용했습니다.

데이터 수정시 Evict가 발생하는 데, Evict와 조회 시점에서 동시성 이슈가 발생해서 데이터가 구버전 데이터로 캐싱되어 정합성이 깨지는 문제가 있었습니다.

락을 통해서 제어할 수 있지만 조회가 느려질 수 있어서 시간을 통해서 제어해줬습니다.

>

## 🙋🏻 More

- 프론트에서 좋아요 표시 여부까지 응답 요구 -> 캐싱 정책 변경 필요

>


close #63