### PR TITLE
refactor: 쇼케이스 페이징 조회를 변경한다

### DIFF
--- a/backend/pcloud-api/docs/asciidoc/exhibition.adoc
+++ b/backend/pcloud-api/docs/asciidoc/exhibition.adoc
@@ -10,67 +10,62 @@
 == 개인전시회를 생성한다 (POST /api/exhibitions)
 
 === Request
+
 include::{snippets}/exhibition-controller-web-mvc-test/create_exhibitions/http-request.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/create_exhibitions/request-headers.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/create_exhibitions/request-fields.adoc[]
 
 === Response
+
 include::{snippets}/exhibition-controller-web-mvc-test/create_exhibitions/http-response.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/create_exhibitions/response-headers.adoc[]
-
 
 == 개인전시회를 상세 조회한다 (GET /api/exhibitions/{exhibitionId})
 
 === Request
+
 include::{snippets}/exhibition-controller-web-mvc-test/find_exhibition/http-request.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/find_exhibition/path-parameters.adoc[]
 
 === Response
+
 include::{snippets}/exhibition-controller-web-mvc-test/find_exhibition/http-response.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/find_exhibition/response-fields.adoc[]
-
-
-== 개인전시회를 페이징 조회한다 (GET /api/exhibitions)
-
-=== Request
-include::{snippets}/exhibition-controller-web-mvc-test/find_all_exhibition_with_paging/http-request.adoc[]
-include::{snippets}/exhibition-controller-web-mvc-test/find_all_exhibition_with_paging/query-parameters.adoc[]
-
-=== Response
-include::{snippets}/exhibition-controller-web-mvc-test/find_all_exhibition_with_paging/http-response.adoc[]
-include::{snippets}/exhibition-controller-web-mvc-test/find_all_exhibition_with_paging/response-fields.adoc[]
-
 
 == 개인전시회를 업데이트 한다 (PATCH /api/exhibitions/{exhibitionId})
 
 === Request
+
 include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/http-request.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/path-parameters.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/request-headers.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/request-fields.adoc[]
 
 === Response
-include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/http-response.adoc[]
 
+include::{snippets}/exhibition-controller-web-mvc-test/patch_exhibition/http-response.adoc[]
 
 == 개인전시회를 삭제한다 (DELETE /api/exhibitions)
 
 === Request
+
 include::{snippets}/exhibition-controller-web-mvc-test/delete_exhibition/http-request.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/delete_exhibition/path-parameters.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/delete_exhibition/request-headers.adoc[]
 
 === Response
-include::{snippets}/exhibition-controller-web-mvc-test/delete_exhibition/http-response.adoc[]
 
+include::{snippets}/exhibition-controller-web-mvc-test/delete_exhibition/http-response.adoc[]
 
 == 개인전시회 좋아요를 처리한다 (POST /api/exhibitions/{exhibitionId}/likes)
 
 === Request
+
 include::{snippets}/exhibition-controller-web-mvc-test/toggle_exhibition_like/http-request.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/toggle_exhibition_like/path-parameters.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/toggle_exhibition_like/request-headers.adoc[]
 
 === Response
+
 include::{snippets}/exhibition-controller-web-mvc-test/toggle_exhibition_like/http-response.adoc[]
 include::{snippets}/exhibition-controller-web-mvc-test/toggle_exhibition_like/response-fields.adoc[]

--- a/backend/pcloud-api/docs/asciidoc/index.adoc
+++ b/backend/pcloud-api/docs/asciidoc/index.adoc
@@ -1,6 +1,7 @@
 ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
+
 = pop-cloud
 :doctype: book
 :toc: left
@@ -11,3 +12,4 @@ include::auth.adoc[]
 include::exhibition.adoc[]
 include::popups.adoc[]
 include::recommends.adoc[]
+include::show.adoc[]

--- a/backend/pcloud-api/docs/asciidoc/popups.adoc
+++ b/backend/pcloud-api/docs/asciidoc/popups.adoc
@@ -41,18 +41,6 @@ include::{snippets}/popups-controller-web-mvc-test/create_popups/http-request.ad
 include::{snippets}/popups-controller-web-mvc-test/create_popups/response-headers.adoc[]
 include::{snippets}/popups-controller-web-mvc-test/create_popups/http-response.adoc[]
 
-== 팝업스토어를 페이징 조회한다 (GET /api/popups?popupsId=${value}&pageSize=${value})
-
-=== Request
-
-include::{snippets}/popups-controller-web-mvc-test/find_all_popups_with_paging/query-parameters.adoc[]
-include::{snippets}/popups-controller-web-mvc-test/find_all_popups_with_paging/http-request.adoc[]
-
-=== Response
-
-include::{snippets}/popups-controller-web-mvc-test/find_all_popups_with_paging/response-fields.adoc[]
-include::{snippets}/popups-controller-web-mvc-test/find_all_popups_with_paging/http-response.adoc[]
-
 == 팝업스토어를 상세 조회한다 (GET /api/popups/{popupsId})
 
 === Request

--- a/backend/pcloud-api/docs/asciidoc/show.adoc
+++ b/backend/pcloud-api/docs/asciidoc/show.adoc
@@ -1,0 +1,18 @@
+= Shows API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== Show의 페이징 조회를 쿼리를 바탕으로 진행한다 (GET /api/shows?showId=:&showType=:&publicTags=[]&city=:&country=[])
+
+=== Request
+
+include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/query-parameters.adoc[]
+include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/response-fields.adoc[]
+include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/http-response.adoc[]

--- a/backend/pcloud-api/docs/asciidoc/show.adoc
+++ b/backend/pcloud-api/docs/asciidoc/show.adoc
@@ -10,6 +10,7 @@
 === Request
 
 include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/query-parameters.adoc[]
+include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/curl-request.adoc[]
 include::{snippets}/show-controller-web-mvc-test/find_all_show_with_paging/http-request.adoc[]
 
 === Response

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionQueryService.java
@@ -2,15 +2,12 @@ package com.api.show.exhibition.application;
 
 import com.common.config.event.Events;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import com.domain.show.exhibition.event.ExhibitionFoundEvent;
 import com.domain.show.exhibition.exception.ExhibitionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static com.domain.show.exhibition.exception.ExhibitionExceptionType.EXHIBITION_NOT_FOUND_EXCEPTION;
 
@@ -25,9 +22,5 @@ public class ExhibitionQueryService {
         Events.raise(new ExhibitionFoundEvent(exhibitionId, clientIp));
         return exhibitionRepository.findSpecificById(exhibitionId)
                 .orElseThrow(() -> new ExhibitionException(EXHIBITION_NOT_FOUND_EXCEPTION));
-    }
-
-    public List<ExhibitionSimpleResponse> findAll(final Long exhibitionId, final Integer pageSize) {
-        return exhibitionRepository.findAllWithPaging(exhibitionId, pageSize);
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/application/ExhibitionService.java
@@ -61,11 +61,16 @@ public class ExhibitionService {
     }
 
     public boolean toggleLike(final Long memberId, final Long exhibitionId) {
-        Exhibition foundExhibition = findExhibition(exhibitionId);
+        Exhibition foundExhibition = findWithOptimisticLock(exhibitionId);
         boolean canAddLikes = toggleExhibitionLike(memberId, exhibitionId);
         foundExhibition.addLikedCount(canAddLikes);
 
         return canAddLikes;
+    }
+
+    private Exhibition findWithOptimisticLock(final Long exhibitionId) {
+        return exhibitionRepository.findByIdWithOptimisticLock(exhibitionId)
+                .orElseThrow(() -> new ExhibitionException(EXHIBITION_NOT_FOUND_EXCEPTION));
     }
 
     private boolean toggleExhibitionLike(final Long memberId, final Long exhibitionId) {

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
@@ -8,7 +8,6 @@ import com.api.show.exhibition.application.dto.ExhibitionUpdateRequest;
 import com.api.show.exhibition.presentation.dto.ExhibitionLikedStatusResponse;
 import com.domain.annotation.AuthMember;
 import com.domain.annotation.AuthMembers;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,11 +18,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-import java.util.List;
 
 import static com.domain.member.domain.vo.MemberRole.ADMIN;
 import static com.domain.member.domain.vo.MemberRole.MANAGER;
@@ -56,14 +53,6 @@ public class ExhibitionController {
             @PathVariable final Long exhibitionId,
             @ClientIpFinder final String clientIp) {
         return ResponseEntity.ok(exhibitionQueryService.findById(exhibitionId, clientIp));
-    }
-
-    @GetMapping
-    public ResponseEntity<List<ExhibitionSimpleResponse>> findAll(
-            @RequestParam(name = "exhibitionId", required = false) final Long exhibitionId,
-            @RequestParam(name = "pageSize") final Integer pageSize
-    ) {
-        return ResponseEntity.ok(exhibitionQueryService.findAll(exhibitionId, pageSize));
     }
 
     @PatchMapping("/{exhibitionId}")

--- a/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/exhibition/presentation/ExhibitionController.java
@@ -51,9 +51,6 @@ public class ExhibitionController {
                 .build();
     }
 
-    /**
-     * TODO: 조회 시 방문자 수 처리 (추후에 유스케이스 적용)
-     */
     @GetMapping("/{exhibitionId}")
     public ResponseEntity<ExhibitionSpecificResponse> findById(
             @PathVariable final Long exhibitionId,

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/application/PopupsQueryService.java
@@ -3,7 +3,6 @@ package com.api.show.popups.application;
 import com.common.config.event.Events;
 import com.domain.show.popups.cache.PopupsCacheRepository;
 import com.domain.show.popups.domain.PopupsRepository;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import com.domain.show.popups.event.PopupsFoundEvent;
 import com.domain.show.popups.exception.PopupsException;
@@ -12,7 +11,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static com.domain.show.popups.exception.PopupsExceptionType.POPUPS_NOT_FOUND_EXCEPTION;
 
@@ -53,9 +51,5 @@ public class PopupsQueryService {
     private boolean canCacheWithoutConcurrency(final LocalDateTime cacheEvictTime, final LocalDateTime startFindTime) {
         return cacheEvictTime == null ||
                 cacheEvictTime.isBefore(startFindTime);
-    }
-
-    public List<PopupsSimpleResponse> findAll(final Long popupsId, final Integer pageSize) {
-        return popupsRepository.findAllWithPaging(popupsId, pageSize);
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/infrastructure/PopupsRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.api.show.popups.infrastructure;
 import com.domain.show.popups.domain.LikedPopups;
 import com.domain.show.popups.domain.Popups;
 import com.domain.show.popups.domain.PopupsRepository;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import com.domain.show.popups.infrastructure.LikedPopupsJpaRepository;
 import com.domain.show.popups.infrastructure.PopupsJpaRepository;
@@ -11,7 +10,6 @@ import com.domain.show.popups.infrastructure.PopupsQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @RequiredArgsConstructor
@@ -40,11 +38,6 @@ public class PopupsRepositoryImpl implements PopupsRepository {
     @Override
     public Optional<PopupsSpecificResponse> findSpecificById(final Long id) {
         return popupsQueryRepository.findSpecificById(id);
-    }
-
-    @Override
-    public List<PopupsSimpleResponse> findAllWithPaging(final Long popupsId, final Integer pageSize) {
-        return popupsQueryRepository.findAllWithPaging(popupsId, pageSize);
     }
 
     @Override

--- a/backend/pcloud-api/src/main/java/com/api/show/popups/presentation/PopupsController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/popups/presentation/PopupsController.java
@@ -8,7 +8,6 @@ import com.api.show.popups.application.request.PopupsUpdateRequest;
 import com.api.show.popups.presentation.response.PopupLikedStatusResponse;
 import com.domain.annotation.AuthMember;
 import com.domain.annotation.AuthMembers;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,11 +17,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
-import java.util.List;
 
 import static com.domain.member.domain.vo.MemberRole.ADMIN;
 import static com.domain.member.domain.vo.MemberRole.MANAGER;
@@ -46,14 +43,6 @@ public class PopupsController {
         Long createdPopupsId = popupsService.create(memberId, request);
         return ResponseEntity.created(URI.create("/popups/" + createdPopupsId))
                 .build();
-    }
-
-    @GetMapping
-    public ResponseEntity<List<PopupsSimpleResponse>> findAll(
-            @RequestParam(name = "popupsId", required = false) final Long popupsId,
-            @RequestParam(name = "pageSize") final Integer pageSize
-    ) {
-        return ResponseEntity.ok(popupsQueryService.findAll(popupsId, pageSize));
     }
 
     @GetMapping("/{popupsId}")

--- a/backend/pcloud-api/src/main/java/com/api/show/show/application/ShowQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/application/ShowQueryService.java
@@ -1,0 +1,28 @@
+package com.api.show.show.application;
+
+import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.domain.show.show.domain.ShowRepository;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ShowQueryService {
+
+    private final ShowRepository showRepository;
+
+    public List<ShowSimpleResponse> findAll(final ShowPagingQueryRequest request) {
+        return showRepository.findAll(
+                request.showId(),
+                request.pageSize(),
+                request.showType(),
+                request.publicTags(),
+                request.cities()
+        );
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/show/application/ShowQueryService.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/application/ShowQueryService.java
@@ -1,6 +1,6 @@
 package com.api.show.show.application;
 
-import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.api.show.show.application.dto.ShowPagingFilterRequest;
 import com.domain.show.show.domain.ShowRepository;
 import com.domain.show.show.domain.dto.ShowSimpleResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +16,15 @@ public class ShowQueryService {
 
     private final ShowRepository showRepository;
 
-    public List<ShowSimpleResponse> findAll(final ShowPagingQueryRequest request) {
+    public List<ShowSimpleResponse> findAll(final ShowPagingFilterRequest request) {
         return showRepository.findAll(
                 request.showId(),
                 request.pageSize(),
                 request.showType(),
                 request.publicTags(),
-                request.cities()
+                request.cities(),
+                request.startDate(),
+                request.endDate()
         );
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/show/application/dto/ShowPagingFilterRequest.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/application/dto/ShowPagingFilterRequest.java
@@ -3,33 +3,43 @@ package com.api.show.show.application.dto;
 import com.domain.show.common.PublicTag;
 import com.domain.show.common.ShowType;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 
-public record ShowPagingQueryRequest(
+public record ShowPagingFilterRequest(
         Long showId,
         Integer pageSize,
         ShowType showType,
         List<PublicTag> publicTags,
-        List<String> cities
+        List<String> cities,
+        LocalDateTime startDate,
+        LocalDateTime endDate
 ) {
 
-    public static ShowPagingQueryRequest of(
+    public static ShowPagingFilterRequest of(
             final Long showId,
             final Integer pageSize,
             String showType,
             final List<String> publicTags,
             final String city,
-            final List<String> country
+            final List<String> country,
+            String startDate,
+            String endDate
     ) {
         showType = showType.toLowerCase();
         validateNotSupportedTag(showType);
-        return new ShowPagingQueryRequest(
+        return new ShowPagingFilterRequest(
                 showId,
                 pageSize,
                 ShowType.from(showType),
                 convertPublicTags(publicTags),
-                convertCities(city, country)
+                convertCities(city, country),
+                parseDate(startDate).toLocalDate().atTime(LocalTime.MIN),
+                parseDate(endDate).toLocalDate().atTime(LocalTime.MAX)
         );
     }
 
@@ -45,7 +55,7 @@ public record ShowPagingQueryRequest(
         }
 
         return country.stream()
-                .filter(ShowPagingQueryRequest::validateStringType)
+                .filter(ShowPagingFilterRequest::validateStringType)
                 .map(it -> String.format("%s %s", city, it))
                 .toList();
     }
@@ -58,5 +68,17 @@ public record ShowPagingQueryRequest(
         return publicTags.stream()
                 .map(PublicTag::from)
                 .toList();
+    }
+
+    private static LocalDateTime parseDate(final String date) {
+        String type = "yyyy-MM-dd";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(type);
+
+        if (date == null || date.isBlank()) {
+            return LocalDateTime.now();
+        }
+
+        LocalDate localDate = LocalDate.parse(date, formatter);
+        return localDate.atStartOfDay();
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/show/application/dto/ShowPagingQueryRequest.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/application/dto/ShowPagingQueryRequest.java
@@ -1,0 +1,62 @@
+package com.api.show.show.application.dto;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+
+import java.util.Collections;
+import java.util.List;
+
+public record ShowPagingQueryRequest(
+        Long showId,
+        Integer pageSize,
+        ShowType showType,
+        List<PublicTag> publicTags,
+        List<String> cities
+) {
+
+    public static ShowPagingQueryRequest of(
+            final Long showId,
+            final Integer pageSize,
+            String showType,
+            final List<String> publicTags,
+            final String city,
+            final List<String> country
+    ) {
+        showType = showType.toLowerCase();
+        validateNotSupportedTag(showType);
+        return new ShowPagingQueryRequest(
+                showId,
+                pageSize,
+                ShowType.from(showType),
+                convertPublicTags(publicTags),
+                convertCities(city, country)
+        );
+    }
+
+    private static void validateNotSupportedTag(final String showType) {
+        if (showType.equals("all")) {
+            throw new IllegalArgumentException("아직 지원하지 않는 태그입니다.");
+        }
+    }
+
+    private static List<String> convertCities(final String city, final List<String> country) {
+        if (city == null || !validateStringType(city)) {
+            return Collections.emptyList();
+        }
+
+        return country.stream()
+                .filter(ShowPagingQueryRequest::validateStringType)
+                .map(it -> String.format("%s %s", city, it))
+                .toList();
+    }
+
+    private static boolean validateStringType(final String country) {
+        return !country.isBlank() && !country.isEmpty();
+    }
+
+    private static List<PublicTag> convertPublicTags(final List<String> publicTags) {
+        return publicTags.stream()
+                .map(PublicTag::from)
+                .toList();
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/show/infrastructure/ShowRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/infrastructure/ShowRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.domain.show.show.infrastructure.ShowQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -17,7 +18,7 @@ public class ShowRepositoryImpl implements ShowRepository {
     private final ShowQueryRepository showQueryRepository;
 
     @Override
-    public List<ShowSimpleResponse> findAll(final Long showId, final Integer PageSize, final ShowType showType, final List<PublicTag> publicTags, final List<String> cities) {
-        return showQueryRepository.findAllWithPaging(showId, PageSize, showType, publicTags, cities);
+    public List<ShowSimpleResponse> findAll(final Long showId, final Integer PageSize, final ShowType showType, final List<PublicTag> publicTags, final List<String> cities, final LocalDateTime startDate, LocalDateTime endDate) {
+        return showQueryRepository.findAllWithPaging(showId, PageSize, showType, publicTags, cities, startDate, endDate);
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/show/infrastructure/ShowRepositoryImpl.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/infrastructure/ShowRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.api.show.show.infrastructure;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+import com.domain.show.show.domain.ShowRepository;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import com.domain.show.show.infrastructure.ShowQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ShowRepositoryImpl implements ShowRepository {
+
+    private final ShowQueryRepository showQueryRepository;
+
+    @Override
+    public List<ShowSimpleResponse> findAll(final Long showId, final Integer PageSize, final ShowType showType, final List<PublicTag> publicTags, final List<String> cities) {
+        return showQueryRepository.findAllWithPaging(showId, PageSize, showType, publicTags, cities);
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
@@ -1,0 +1,34 @@
+package com.api.show.show.presentation;
+
+import com.api.show.show.application.ShowQueryService;
+import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/shows")
+@RestController
+public class ShowController {
+
+    private final ShowQueryService showQueryService;
+
+    @GetMapping
+    public ResponseEntity<List<ShowSimpleResponse>> findAll(
+            @RequestParam(required = false) final Long showId,
+            @RequestParam(required = false, defaultValue = "10") final Integer pageSize,
+            @RequestParam(required = false, defaultValue = "popups") final String showType,
+            @RequestParam(required = false, defaultValue = "") final List<String> publicTags,
+            @RequestParam(required = false, defaultValue = "") final String city,
+            @RequestParam(required = false, defaultValue = "") final List<String> country
+    ) {
+        ShowPagingQueryRequest request = ShowPagingQueryRequest.of(showId, pageSize, showType, publicTags, city, country);
+        return ResponseEntity.ok(showQueryService.findAll(request));
+    }
+}

--- a/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
@@ -1,7 +1,7 @@
 package com.api.show.show.presentation;
 
 import com.api.show.show.application.ShowQueryService;
-import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.api.show.show.application.dto.ShowPagingFilterRequest;
 import com.domain.show.show.domain.dto.ShowSimpleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,9 +26,11 @@ public class ShowController {
             @RequestParam(required = false, defaultValue = "popups") final String showType,
             @RequestParam(required = false, defaultValue = "") final List<String> publicTags,
             @RequestParam(required = false, defaultValue = "") final String city,
-            @RequestParam(required = false, defaultValue = "") final List<String> country
+            @RequestParam(required = false, defaultValue = "") final List<String> country,
+            @RequestParam(required = false, defaultValue = "") final String startDate,
+            @RequestParam(required = false, defaultValue = "") final String endDate
     ) {
-        ShowPagingQueryRequest request = ShowPagingQueryRequest.of(showId, pageSize, showType, publicTags, city, country);
+        ShowPagingFilterRequest request = ShowPagingFilterRequest.of(showId, pageSize, showType, publicTags, city, country, startDate, endDate);
         return ResponseEntity.ok(showQueryService.findAll(request));
     }
 }

--- a/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
+++ b/backend/pcloud-api/src/main/java/com/api/show/show/presentation/ShowController.java
@@ -27,8 +27,8 @@ public class ShowController {
             @RequestParam(required = false, defaultValue = "") final List<String> publicTags,
             @RequestParam(required = false, defaultValue = "") final String city,
             @RequestParam(required = false, defaultValue = "") final List<String> country,
-            @RequestParam(required = false, defaultValue = "") final String startDate,
-            @RequestParam(required = false, defaultValue = "") final String endDate
+            @RequestParam(required = true) final String startDate,
+            @RequestParam(required = true) final String endDate
     ) {
         ShowPagingFilterRequest request = ShowPagingFilterRequest.of(showId, pageSize, showType, publicTags, city, country, startDate, endDate);
         return ResponseEntity.ok(showQueryService.findAll(request));

--- a/backend/pcloud-api/src/test/java/com/api/helper/MockBeanInjection.java
+++ b/backend/pcloud-api/src/test/java/com/api/helper/MockBeanInjection.java
@@ -10,6 +10,7 @@ import com.api.show.popups.application.PopupsQueryService;
 import com.api.show.popups.application.PopupsService;
 import com.api.show.recommend.application.RecommendService;
 import com.api.show.recommend.presentation.resolver.PopularShowRequestArgumentResolver;
+import com.api.show.show.application.ShowQueryService;
 import com.common.auth.TokenProvider;
 import com.domain.member.domain.MemberRepository;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -53,4 +54,7 @@ public class MockBeanInjection {
 
     @MockBean
     protected RecommendService recommendService;
+
+    @MockBean
+    protected ShowQueryService showQueryService;
 }

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/application/ExhibitionQueryServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/application/ExhibitionQueryServiceTest.java
@@ -2,24 +2,16 @@ package com.api.show.exhibition.application;
 
 import com.domain.show.exhibition.domain.Exhibition;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
-import show.exhibition.infrasturcture.ExhibitionFakeRepository;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.LongStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
+import show.exhibition.infrasturcture.ExhibitionFakeRepository;
 
-import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전;
-import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
-import static show.exhibition.domain.ExhibitionSimpleResponseFixture.개인전시회_간단_조회_응답_생성_개인전시회;
-import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성_개인전시회;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전;
+import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성_개인전시회;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -48,34 +40,5 @@ class ExhibitionQueryServiceTest {
         ExhibitionSpecificResponse expectedResponse = 개인전시회_상세_조회_응답_생성_개인전시회(savedExhibition);
         assertThat(response).usingRecursiveComparison()
                 .isEqualTo(expectedResponse);
-    }
-
-    @Test
-    void 개인전시회를_페이징_조회한다() {
-        // given
-        List<Exhibition> exhibitions = new ArrayList<>();
-        LongStream.rangeClosed(1, 10)
-                .forEach(index -> {
-                    Exhibition savedExhibition = exhibitionRepository.save(개인전시회_생성_사진_개인전_작성자아이디(index));
-                    exhibitions.add(savedExhibition);
-                });
-        exhibitions.sort(Comparator.comparing(Exhibition::getId).reversed());
-
-        // when
-        List<ExhibitionSimpleResponse> responses = exhibitionQueryService.findAll(8L, 3);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(responses).hasSize(3);
-            softly.assertThat(responses.get(0))
-                    .usingRecursiveComparison()
-                    .isEqualTo(개인전시회_간단_조회_응답_생성_개인전시회(exhibitions.get(3)));
-            softly.assertThat(responses.get(1))
-                    .usingRecursiveComparison()
-                    .isEqualTo(개인전시회_간단_조회_응답_생성_개인전시회(exhibitions.get(4)));
-            softly.assertThat(responses.get(2))
-                    .usingRecursiveComparison()
-                    .isEqualTo(개인전시회_간단_조회_응답_생성_개인전시회(exhibitions.get(5)));
-        });
     }
 }

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerAcceptanceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerAcceptanceTest.java
@@ -36,18 +36,6 @@ class ExhibitionControllerAcceptanceTest extends ExhibitionControllerAcceptanceT
     }
 
     @Test
-    void 개인전시회를_페이징_조회한다() {
-        // given
-        개인전시회_생성();
-
-        // when
-        var 개인전시회_페이징_조회_요청_결과 = 개인전시회_페이징_조회_요청();
-
-        // then
-        개인전시회_페이징_조회_요청_검증(개인전시회_페이징_조회_요청_결과);
-    }
-
-    @Test
     void 개인전시회를_업데이트한다() {
         // given
         개인전시회_생성();

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerAcceptanceTestFixture.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerAcceptanceTestFixture.java
@@ -1,9 +1,9 @@
 package com.api.show.exhibition.presentation;
 
+import com.api.helper.AcceptanceBaseFixture;
 import com.api.show.exhibition.application.dto.ExhibitionCreateRequest;
 import com.api.show.exhibition.application.dto.ExhibitionUpdateRequest;
 import com.api.show.exhibition.presentation.dto.ExhibitionLikedStatusResponse;
-import com.api.helper.AcceptanceBaseFixture;
 import com.domain.show.exhibition.domain.Exhibition;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
 import io.restassured.RestAssured;
@@ -16,9 +16,9 @@ import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -58,18 +58,6 @@ class ExhibitionControllerAcceptanceTestFixture extends AcceptanceBaseFixture {
     }
 
     protected void 개인전시회_상세_조회_요청_검증(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    protected ExtractableResponse<Response> 개인전시회_페이징_조회_요청() {
-        return RestAssured.given().log().all()
-                .when()
-                .get("/exhibitions?pageSize=1")
-                .then().log().all()
-                .extract();
-    }
-
-    protected void 개인전시회_페이징_조회_요청_검증(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
@@ -1,14 +1,12 @@
 package com.api.show.exhibition.presentation;
 
+import com.api.helper.MockBeanInjection;
 import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.exhibition.application.dto.ExhibitionCreateRequest;
 import com.api.show.exhibition.application.dto.ExhibitionUpdateRequest;
-import com.api.helper.MockBeanInjection;
 import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -17,15 +15,16 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.Optional;
+
+import static com.api.helper.RestDocsHelper.customDocument;
 import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인전시회_생성_요청_생성;
 import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인전시회_업데이트_요청_생성;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static show.exhibition.domain.ExhibitionSimpleResponseFixture.개인전시회_간단_조회_응답_생성;
-import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성;
-import static com.api.helper.RestDocsHelper.customDocument;
 import static member.fixture.MemberFixture.어드민_멤버_생성_id_없음_kakao_oauth_가입;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doNothing;
@@ -46,6 +45,8 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static show.exhibition.domain.ExhibitionSimpleResponseFixture.개인전시회_간단_조회_응답_생성;
+import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -168,7 +169,8 @@ class ExhibitionControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("[].startDate").description("개인전시회 시작일"),
                                 fieldWithPath("[].endDate").description("개인전시회 종료일"),
                                 fieldWithPath("[].visitedCount").description("개인전시회 게시글 방문자 수"),
-                                fieldWithPath("[].likedCount").description("개인전시회 게시글 좋아요 수")
+                                fieldWithPath("[].likedCount").description("개인전시회 게시글 좋아요 수"),
+                                fieldWithPath("[].showType").description("쇼 타입 (POPUPS OR EXHIBITION)")
                         )
                 ));
     }

--- a/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/exhibition/presentation/ExhibitionControllerWebMvcTest.java
@@ -4,7 +4,6 @@ import com.api.helper.MockBeanInjection;
 import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.exhibition.application.dto.ExhibitionCreateRequest;
 import com.api.show.exhibition.application.dto.ExhibitionUpdateRequest;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -15,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.api.helper.RestDocsHelper.customDocument;
@@ -23,7 +21,6 @@ import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인�
 import static com.api.show.exhibition.fixture.ExhibitionRequestFixtures.개인전시회_업데이트_요청_생성;
 import static member.fixture.MemberFixture.어드민_멤버_생성_id_없음_kakao_oauth_가입;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyLong;
@@ -43,9 +40,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static show.exhibition.domain.ExhibitionSimpleResponseFixture.개인전시회_간단_조회_응답_생성;
 import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -142,35 +137,6 @@ class ExhibitionControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("visitedCount").description("개인전시회 게시글 방문자 수"),
                                 fieldWithPath("likedCount").description("개인전시회 게시글 좋아요 수"),
                                 fieldWithPath("tags[]").description("커스텀 태그")
-                        )
-                ));
-    }
-
-    @Test
-    void 개인전시회를_페이징_조회한다() throws Exception {
-        // given
-        List<ExhibitionSimpleResponse> responses = List.of(개인전시회_간단_조회_응답_생성());
-        when(exhibitionQueryService.findAll(anyLong(), anyInt())).thenReturn(responses);
-
-        // when & then
-        mockMvc.perform(get("/exhibitions")
-                        .param("exhibitionId", "11")
-                        .param("pageSize", "10")
-                ).andExpect(status().isOk())
-                .andDo(customDocument("find_all_exhibition_with_paging",
-                        queryParameters(
-                                parameterWithName("exhibitionId").description("마지막으로 받은 개인전시회 id, 처음 조회 시 null"),
-                                parameterWithName("pageSize").description("한 페이지에 조회되는 데이터 수")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].exhibitionId").description("개인전시회 id"),
-                                fieldWithPath("[].title").description("개인전시회 이름"),
-                                fieldWithPath("[].location").description("개인전시회 열리는 장소"),
-                                fieldWithPath("[].startDate").description("개인전시회 시작일"),
-                                fieldWithPath("[].endDate").description("개인전시회 종료일"),
-                                fieldWithPath("[].visitedCount").description("개인전시회 게시글 방문자 수"),
-                                fieldWithPath("[].likedCount").description("개인전시회 게시글 좋아요 수"),
-                                fieldWithPath("[].showType").description("쇼 타입 (POPUPS OR EXHIBITION)")
                         )
                 ));
     }

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerAcceptanceFixture.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerAcceptanceFixture.java
@@ -50,18 +50,6 @@ class PopupsControllerAcceptanceFixture extends AcceptanceBaseFixture {
         return popupsRepository.save(일반_팝업_스토어_생성_뷰티());
     }
 
-    protected ExtractableResponse<Response> 팝업스토어_페이징_조회_요청() {
-        return RestAssured.given().log().all()
-                .when()
-                .get("/popups?pageSize=1")
-                .then().log().all()
-                .extract();
-    }
-
-    protected void 페이징_조회_결과_검증(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
     protected ExtractableResponse<Response> 팝업스토어_업데이트_요청() {
         return RestAssured.given().log().all()
                 .when()

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerAcceptanceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerAcceptanceTest.java
@@ -21,18 +21,6 @@ class PopupsControllerAcceptanceTest extends PopupsControllerAcceptanceFixture {
     }
 
     @Test
-    void 팝업스토어_페이징_조회() {
-        // given
-        팝업_스토어_생성();
-
-        // when
-        var 요청_결과 = 팝업스토어_페이징_조회_요청();
-
-        // then
-        페이징_조회_결과_검증(요청_결과);
-    }
-
-    @Test
     void 팝업스토어_상세_조회() {
         // given
         팝업_스토어_생성();

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
@@ -123,8 +123,8 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                                 fieldWithPath("[].startDate").description("팝업스토어 시작일"),
                                 fieldWithPath("[].endDate").description("팝업스토어 종료일"),
                                 fieldWithPath("[].visitedCount").description("팝업스토어 게시글 방문자 수"),
-                                fieldWithPath("[].likedCount").description("팝업스토어 게시글 좋아요 수")
-
+                                fieldWithPath("[].likedCount").description("팝업스토어 게시글 좋아요 수"),
+                                fieldWithPath("[].showType").description("쇼 타입 (POPUPS or EXHIBITION)")
                         )
                 ));
     }

--- a/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/popups/presentation/PopupsControllerWebMvcTest.java
@@ -4,7 +4,6 @@ import com.api.helper.MockBeanInjection;
 import com.api.show.common.resolver.ClientIpFinderResolver;
 import com.api.show.popups.application.request.PopupsCreateRequest;
 import com.api.show.popups.application.request.PopupsUpdateRequest;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -16,8 +15,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import static com.api.helper.RestDocsHelper.customDocument;
@@ -42,7 +39,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static show.popups.domain.PopupsSpecificResponseFixture.팝업스토어_상세_조회_응답_생성;
 
@@ -97,34 +93,6 @@ class PopupsControllerWebMvcTest extends MockBeanInjection {
                         ),
                         responseHeaders(
                                 headerWithName("location").description("생성된 팝업스토어 redirection URL")
-                        )
-                ));
-    }
-
-    @Test
-    void 페이징_조회를_한다() throws Exception {
-        // given
-        when(popupsQueryService.findAll(any(), any())).thenReturn(List.of(new PopupsSimpleResponse(1L, "빵빵이 전시회", "서울특별시 마포구", LocalDateTime.now().minusDays(30), LocalDateTime.now(), 0, 0)));
-
-        // when & then
-        mockMvc.perform(get("/popups")
-                        .param("popupsId", "11")
-                        .param("pageSize", "10")
-                ).andExpect(status().isOk())
-                .andDo(customDocument("find_all_popups_with_paging",
-                        queryParameters(
-                                parameterWithName("popupsId").description("마지막으로 받은 popupsId, 맨 처음 조회라면 null 허용"),
-                                parameterWithName("pageSize").description("한 페이지에 조회되는 사이즈")
-                        ),
-                        responseFields(
-                                fieldWithPath("[].id").description("팝업스토어 id"),
-                                fieldWithPath("[].title").description("팝업스토어 이름"),
-                                fieldWithPath("[].location").description("팝업스토어 장소명"),
-                                fieldWithPath("[].startDate").description("팝업스토어 시작일"),
-                                fieldWithPath("[].endDate").description("팝업스토어 종료일"),
-                                fieldWithPath("[].visitedCount").description("팝업스토어 게시글 방문자 수"),
-                                fieldWithPath("[].likedCount").description("팝업스토어 게시글 좋아요 수"),
-                                fieldWithPath("[].showType").description("쇼 타입 (POPUPS or EXHIBITION)")
                         )
                 ));
     }

--- a/backend/pcloud-api/src/test/java/com/api/show/show/application/ShowQueryServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/application/ShowQueryServiceTest.java
@@ -1,6 +1,6 @@
 package com.api.show.show.application;
 
-import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.api.show.show.application.dto.ShowPagingFilterRequest;
 import com.domain.show.show.domain.ShowRepository;
 import com.domain.show.show.domain.dto.ShowSimpleResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.domain.show.common.PublicTag.ARTIST;
@@ -33,9 +34,9 @@ class ShowQueryServiceTest {
     @Test
     void 페이징_조회를_한다() {
         // given
-        ShowPagingQueryRequest request = new ShowPagingQueryRequest(1L, 10, null, null, null);
+        ShowPagingFilterRequest request = new ShowPagingFilterRequest(1L, 10, null, null, null, LocalDateTime.of(2024, 1, 1, 0, 0), LocalDateTime.of(2025, 1, 1, 0, 0));
         ShowSimpleResponse response = new ShowSimpleResponse(1L, EXHIBITION, ARTIST, "title", "location", null, null, 1, 1);
-        when(showRepository.findAll(any(), any(), any(), any(), any()))
+        when(showRepository.findAll(any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(List.of(response));
 
         // when

--- a/backend/pcloud-api/src/test/java/com/api/show/show/application/ShowQueryServiceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/application/ShowQueryServiceTest.java
@@ -1,0 +1,50 @@
+package com.api.show.show.application;
+
+import com.api.show.show.application.dto.ShowPagingQueryRequest;
+import com.domain.show.show.domain.ShowRepository;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.domain.show.common.PublicTag.ARTIST;
+import static com.domain.show.common.ShowType.EXHIBITION;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ShowQueryServiceTest {
+
+    private ShowQueryService showQueryService;
+    private ShowRepository showRepository;
+
+    @BeforeEach
+    void setup() {
+        showRepository = mock(ShowRepository.class);
+        showQueryService = new ShowQueryService(showRepository);
+    }
+
+    @Test
+    void 페이징_조회를_한다() {
+        // given
+        ShowPagingQueryRequest request = new ShowPagingQueryRequest(1L, 10, null, null, null);
+        ShowSimpleResponse response = new ShowSimpleResponse(1L, EXHIBITION, ARTIST, "title", "location", null, null, 1, 1);
+        when(showRepository.findAll(any(), any(), any(), any(), any()))
+                .thenReturn(List.of(response));
+
+        // when
+        List<ShowSimpleResponse> result = showQueryService.findAll(request);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0)).isEqualTo(response);
+        });
+    }
+}

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceFixture.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceFixture.java
@@ -1,0 +1,39 @@
+package com.api.show.show.presentation;
+
+import com.api.helper.AcceptanceBaseFixture;
+import com.domain.show.exhibition.domain.Exhibition;
+import com.domain.show.exhibition.domain.ExhibitionRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class ShowControllerAcceptanceFixture extends AcceptanceBaseFixture {
+
+    @Autowired
+    private ExhibitionRepository exhibitionRepository;
+
+    protected Exhibition 개인전시회_생성() {
+        return exhibitionRepository.save(개인전시회_생성_사진_개인전_작성자아이디(관리자.getId()));
+    }
+
+    protected ExtractableResponse<Response> 페이징_조회_요청() {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/shows?pageSize=1&showType=exhibition")
+                .then().log().all()
+                .extract();
+    }
+
+    protected void 페이징_조회_요청_검증(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceFixture.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceFixture.java
@@ -28,7 +28,7 @@ public class ShowControllerAcceptanceFixture extends AcceptanceBaseFixture {
     protected ExtractableResponse<Response> 페이징_조회_요청() {
         return RestAssured.given().log().all()
                 .when()
-                .get("/shows?pageSize=1&showType=exhibition")
+                .get("/shows?pageSize=1&showType=exhibition&startDate=2020-01-01&endDate=2025-12-31")
                 .then().log().all()
                 .extract();
     }

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerAcceptanceTest.java
@@ -1,0 +1,18 @@
+package com.api.show.show.presentation;
+
+import org.junit.jupiter.api.Test;
+
+class ShowControllerAcceptanceTest extends ShowControllerAcceptanceFixture {
+
+    @Test
+    void show_페이징_조회한다() {
+        // given
+        개인전시회_생성();
+
+        // when
+        var 개인전시회_페이징_조회_요청_결과 = 페이징_조회_요청();
+
+        // then
+        페이징_조회_요청_검증(개인전시회_페이징_조회_요청_결과);
+    }
+}

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
@@ -53,12 +53,12 @@ class ShowControllerWebMvcTest extends MockBeanInjection {
                         queryParameters(
                                 parameterWithName("showId").description("마지막으로 받은 show id, 처음 조회 시 null"),
                                 parameterWithName("pageSize").description("한 페이지에 조회되는 데이터 수"),
-                                parameterWithName("showType").description("쇼케이스 타입 (영문 소문자 popups or exhibition)"),
+                                parameterWithName("showType").description("[기본 값 : popups] 쇼케이스 타입 (영문 소문자 popups or exhibition)"),
                                 parameterWithName("publicTags").description("퍼블릭 태그 (한글 값) -> 배열"),
                                 parameterWithName("city").description("도시 이름 (ex. 서울, 경기도 ...)"),
                                 parameterWithName("country").description("상세 위치 (ex. 동작구, 마포구 ...) -> 배열"),
-                                parameterWithName("startDate").description("쇼케이스 시작 날짜"),
-                                parameterWithName("endDate").description("쇼케이스 종료 날짜")
+                                parameterWithName("startDate").description("[필수 값] 쇼케이스 시작 날짜"),
+                                parameterWithName("endDate").description("[필수 값] 쇼케이스 종료 날짜")
                         ),
                         responseFields(
                                 fieldWithPath("[].showId").description("show id"),

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
@@ -1,0 +1,72 @@
+package com.api.show.show.presentation;
+
+import com.api.helper.MockBeanInjection;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.api.helper.RestDocsHelper.customDocument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static show.show.domain.dto.ShowSimpleResponseFixture.쇼_페이징_요소_반환;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureRestDocs
+@WebMvcTest(controllers = ShowController.class)
+class ShowControllerWebMvcTest extends MockBeanInjection {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void 개인전시회를_페이징_조회한다() throws Exception {
+        // given
+        List<ShowSimpleResponse> responses = List.of(쇼_페이징_요소_반환());
+        when(showQueryService.findAll(any())).thenReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/shows")
+                        .param("showId", "10")
+                        .param("pageSize", "10")
+                        .param("showType", "exhibition")
+                        .param("publicTags", "캐릭터")
+                        .param("city", "서울")
+                        .param("country", "동작구")
+                ).andExpect(status().isOk())
+                .andDo(customDocument("find_all_show_with_paging",
+                        queryParameters(
+                                parameterWithName("showId").description("마지막으로 받은 show id, 처음 조회 시 null"),
+                                parameterWithName("pageSize").description("한 페이지에 조회되는 데이터 수"),
+                                parameterWithName("showType").description("쇼 타입 (영문 소문자 popups or exhibition)"),
+                                parameterWithName("publicTags").description("퍼블릭 태그 (한글 값) -> 배열"),
+                                parameterWithName("city").description("도시 이름 (ex. 서울, 경기도 ...)"),
+                                parameterWithName("country").description("상세 위치 (ex. 동작구, 마포구 ...) -> 배열")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].showId").description("show id"),
+                                fieldWithPath("[].showType").description("show id"),
+                                fieldWithPath("[].publicTag").description("퍼블릭 태그 명"),
+                                fieldWithPath("[].title").description("show 이름"),
+                                fieldWithPath("[].location").description("show가 열리는 장소"),
+                                fieldWithPath("[].startDate").description("show 시작일"),
+                                fieldWithPath("[].endDate").description("show 종료일"),
+                                fieldWithPath("[].visitedCount").description("show 게시글 방문자 수"),
+                                fieldWithPath("[].likedCount").description("show 게시글 좋아요 수")
+                        )
+                ));
+    }
+}

--- a/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
+++ b/backend/pcloud-api/src/test/java/com/api/show/show/presentation/ShowControllerWebMvcTest.java
@@ -46,15 +46,19 @@ class ShowControllerWebMvcTest extends MockBeanInjection {
                         .param("publicTags", "캐릭터")
                         .param("city", "서울")
                         .param("country", "동작구")
+                        .param("startDate", "2024-01-01")
+                        .param("endDate", "2024-12-31")
                 ).andExpect(status().isOk())
                 .andDo(customDocument("find_all_show_with_paging",
                         queryParameters(
                                 parameterWithName("showId").description("마지막으로 받은 show id, 처음 조회 시 null"),
                                 parameterWithName("pageSize").description("한 페이지에 조회되는 데이터 수"),
-                                parameterWithName("showType").description("쇼 타입 (영문 소문자 popups or exhibition)"),
+                                parameterWithName("showType").description("쇼케이스 타입 (영문 소문자 popups or exhibition)"),
                                 parameterWithName("publicTags").description("퍼블릭 태그 (한글 값) -> 배열"),
                                 parameterWithName("city").description("도시 이름 (ex. 서울, 경기도 ...)"),
-                                parameterWithName("country").description("상세 위치 (ex. 동작구, 마포구 ...) -> 배열")
+                                parameterWithName("country").description("상세 위치 (ex. 동작구, 마포구 ...) -> 배열"),
+                                parameterWithName("startDate").description("쇼케이스 시작 날짜"),
+                                parameterWithName("endDate").description("쇼케이스 종료 날짜")
                         ),
                         responseFields(
                                 fieldWithPath("[].showId").description("show id"),

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/ExhibitionRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/ExhibitionRepository.java
@@ -1,8 +1,7 @@
 package com.domain.show.exhibition.domain;
 
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
-import java.util.List;
+
 import java.util.Optional;
 
 public interface ExhibitionRepository {
@@ -16,8 +15,6 @@ public interface ExhibitionRepository {
     Optional<Exhibition> findByIdWithOptimisticLock(Long exhibitionId);
 
     Optional<ExhibitionSpecificResponse> findSpecificById(Long exhibitionId);
-
-    List<ExhibitionSimpleResponse> findAllWithPaging(Long exhibitionId, Integer pageSize);
 
     boolean existsByExhibitionIdAndMemberId(Long exhibitionId, Long memberId);
 

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/dto/ExhibitionSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/domain/dto/ExhibitionSimpleResponse.java
@@ -1,5 +1,7 @@
 package com.domain.show.exhibition.domain.dto;
 
+import com.domain.show.common.ShowType;
+
 import java.time.LocalDateTime;
 
 public record ExhibitionSimpleResponse(
@@ -9,6 +11,11 @@ public record ExhibitionSimpleResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         Integer visitedCount,
-        Integer likedCount
+        Integer likedCount,
+        ShowType showType
 ) {
+
+    public ExhibitionSimpleResponse(final Long exhibitionId, final String title, final String location, final LocalDateTime startDate, final LocalDateTime endDate, final Integer visitedCount, final Integer likedCount) {
+        this(exhibitionId, title, location, startDate, endDate, visitedCount, likedCount, ShowType.EXHIBITION);
+    }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionQueryRepository.java
@@ -1,9 +1,7 @@
 package com.domain.show.exhibition.infrastructure;
 
 import com.domain.common.CustomTagType;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -59,29 +57,5 @@ public class ExhibitionQueryRepository {
         }
 
         return Optional.of(result.get(0));
-    }
-
-    public List<ExhibitionSimpleResponse> findAllWithPaging(final Long exhibitionId, final Integer pageSize) {
-        return jpaQueryFactory.select(constructor(ExhibitionSimpleResponse.class,
-                        exhibition.id,
-                        exhibition.showDetails.title,
-                        exhibition.position.location,
-                        exhibition.showSchedule.startDate,
-                        exhibition.showSchedule.endDate,
-                        exhibition.statistic.visitedCount,
-                        exhibition.statistic.likedCount
-                )).from(exhibition)
-                .where(ltExhibitionId(exhibitionId))
-                .orderBy(exhibition.id.desc())
-                .limit(pageSize)
-                .fetch();
-    }
-
-    private BooleanExpression ltExhibitionId(final Long exhibitionId) {
-        if (exhibitionId == null) {
-            return null;
-        }
-
-        return exhibition.id.lt(exhibitionId);
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionRepositoryImpl.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/exhibition/infrastructure/ExhibitionRepositoryImpl.java
@@ -3,12 +3,11 @@ package com.domain.show.exhibition.infrastructure;
 import com.domain.show.exhibition.domain.Exhibition;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
 import com.domain.show.exhibition.domain.LikedExhibition;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -41,11 +40,6 @@ public class ExhibitionRepositoryImpl implements ExhibitionRepository {
     @Override
     public Optional<ExhibitionSpecificResponse> findSpecificById(final Long exhibitionId) {
         return exhibitionQueryRepository.findSpecificById(exhibitionId);
-    }
-
-    @Override
-    public List<ExhibitionSimpleResponse> findAllWithPaging(final Long exhibitionId, final Integer pageSize) {
-        return exhibitionQueryRepository.findAllWithPaging(exhibitionId, pageSize);
     }
 
     @Override

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/PopupsRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/PopupsRepository.java
@@ -1,9 +1,7 @@
 package com.domain.show.popups.domain;
 
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface PopupsRepository {
@@ -15,8 +13,6 @@ public interface PopupsRepository {
     Popups save(Popups popups);
 
     Optional<PopupsSpecificResponse> findSpecificById(Long id);
-
-    List<PopupsSimpleResponse> findAllWithPaging(Long popupsId, Integer pageSize);
 
     boolean existsByProductIdAndMemberId(Long popupsId, Long memberId);
 

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/response/PopupsSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/domain/response/PopupsSimpleResponse.java
@@ -1,5 +1,7 @@
 package com.domain.show.popups.domain.response;
 
+import com.domain.show.common.ShowType;
+
 import java.time.LocalDateTime;
 
 public record PopupsSimpleResponse(
@@ -9,6 +11,11 @@ public record PopupsSimpleResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         Integer visitedCount,
-        Integer likedCount
+        Integer likedCount,
+        ShowType showType
 ) {
+
+    public PopupsSimpleResponse(final Long id, final String title, final String location, final LocalDateTime startDate, final LocalDateTime endDate, final Integer visitedCount, final Integer likedCount) {
+        this(id, title, location, startDate, endDate, visitedCount, likedCount, ShowType.POPUPS);
+    }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/popups/infrastructure/PopupsQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/popups/infrastructure/PopupsQueryRepository.java
@@ -1,21 +1,19 @@
 package com.domain.show.popups.infrastructure;
 
 import com.domain.common.CustomTagType;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 import static com.domain.customtag.domain.QCustomTag.customTag;
 import static com.domain.show.popups.domain.QPopups.popups;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
-import static com.querydsl.core.types.Projections.constructor;
 
 @RequiredArgsConstructor
 @Repository
@@ -59,29 +57,5 @@ public class PopupsQueryRepository {
         }
 
         return Optional.of(result.get(0));
-    }
-
-    public List<PopupsSimpleResponse> findAllWithPaging(final Long popupsId, final Integer pageSize) {
-        return jpaQueryFactory.select(constructor(PopupsSimpleResponse.class,
-                        popups.id,
-                        popups.showDetails.title,
-                        popups.position.location,
-                        popups.showSchedule.startDate,
-                        popups.showSchedule.endDate,
-                        popups.statistic.visitedCount,
-                        popups.statistic.likedCount
-                )).from(popups)
-                .where(ltPopupsId(popupsId))
-                .orderBy(popups.id.desc())
-                .limit(pageSize)
-                .fetch();
-    }
-
-    private BooleanExpression ltPopupsId(final Long popupsId) {
-        if (popupsId == null) {
-            return null;
-        }
-
-        return popups.id.lt(popupsId);
     }
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/ShowRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/ShowRepository.java
@@ -4,9 +4,10 @@ import com.domain.show.common.PublicTag;
 import com.domain.show.common.ShowType;
 import com.domain.show.show.domain.dto.ShowSimpleResponse;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ShowRepository {
 
-    List<ShowSimpleResponse> findAll(Long showId, Integer PageSize, ShowType showType, List<PublicTag> publicTags, List<String> cities);
+    List<ShowSimpleResponse> findAll(Long showId, Integer PageSize, ShowType showType, List<PublicTag> publicTags, List<String> cities, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/ShowRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/ShowRepository.java
@@ -1,0 +1,12 @@
+package com.domain.show.show.domain;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+
+import java.util.List;
+
+public interface ShowRepository {
+
+    List<ShowSimpleResponse> findAll(Long showId, Integer PageSize, ShowType showType, List<PublicTag> publicTags, List<String> cities);
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/dto/ShowSimpleResponse.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/show/domain/dto/ShowSimpleResponse.java
@@ -1,0 +1,33 @@
+package com.domain.show.show.domain.dto;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+
+import java.time.LocalDateTime;
+
+public record ShowSimpleResponse(
+        Long showId,
+        ShowType showType,
+        String publicTag,
+        String title,
+        String location,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        Integer visitedCount,
+        Integer likedCount
+) {
+
+    public ShowSimpleResponse(final Long showId, final ShowType showType, final PublicTag publicTag, final String title, final String location, final LocalDateTime startDate, final LocalDateTime endDate, final Integer visitedCount, final Integer likedCount) {
+        this(
+                showId,
+                showType,
+                publicTag.getName(),
+                title,
+                location,
+                startDate,
+                endDate,
+                visitedCount,
+                likedCount
+        );
+    }
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/show/infrastructure/ShowQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/show/infrastructure/ShowQueryRepository.java
@@ -1,0 +1,135 @@
+package com.domain.show.show.infrastructure;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.domain.show.exhibition.domain.QExhibition.exhibition;
+import static com.domain.show.popups.domain.QPopups.popups;
+import static com.querydsl.core.types.Projections.constructor;
+
+@RequiredArgsConstructor
+@Repository
+public class ShowQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<ShowSimpleResponse> findAllWithPaging(
+            final Long showId,
+            final Integer pageSize,
+            final ShowType showType,
+            final List<PublicTag> publicTags,
+            final List<String> cities
+    ) {
+        if (showType.equals(ShowType.EXHIBITION)) {
+            return fetchExhibition(showId, pageSize, publicTags, cities);
+        }
+
+        return fetchPopups(showId, pageSize, publicTags, cities);
+    }
+
+    private List<ShowSimpleResponse> fetchExhibition(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities) {
+        return jpaQueryFactory.select(constructor(ShowSimpleResponse.class,
+                        exhibition.id,
+                        Expressions.constant(ShowType.EXHIBITION),
+                        exhibition.publicTag,
+                        exhibition.showDetails.title,
+                        exhibition.position.location,
+                        exhibition.showSchedule.startDate,
+                        exhibition.showSchedule.endDate,
+                        exhibition.statistic.visitedCount,
+                        exhibition.statistic.likedCount
+                )).from(exhibition)
+                .where(
+                        ltExhibitionId(showId),
+                        eqPublicTags(publicTags),
+                        eqCities(cities)
+                )
+                .orderBy(exhibition.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression ltExhibitionId(final Long exhibitionId) {
+        if (exhibitionId == null) {
+            return null;
+        }
+
+        return exhibition.id.lt(exhibitionId);
+    }
+
+    private BooleanExpression eqPublicTags(final List<PublicTag> publicTags) {
+        if (publicTags.isEmpty()) {
+            return null;
+        }
+
+        return exhibition.publicTag.in(publicTags);
+    }
+
+    private BooleanExpression eqCities(final List<String> cities) {
+        if (cities.isEmpty()) {
+            return null;
+        }
+
+        return cities.stream()
+                .map(exhibition.position.location::startsWith)
+                .reduce(BooleanExpression::or)
+                .orElse(null);
+    }
+
+    private List<ShowSimpleResponse> fetchPopups(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities) {
+        return jpaQueryFactory.select(constructor(ShowSimpleResponse.class,
+                        popups.id,
+                        Expressions.constant(ShowType.POPUPS),
+                        popups.publicTag,
+                        popups.showDetails.title,
+                        popups.position.location,
+                        popups.showSchedule.startDate,
+                        popups.showSchedule.endDate,
+                        popups.statistic.visitedCount,
+                        popups.statistic.likedCount
+                )).from(popups)
+                .where(
+                        ltPopupsId(showId),
+                        eqPublicTagsWithPopups(publicTags),
+                        eqCitiesWithPopups(cities)
+                )
+                .orderBy(popups.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression ltPopupsId(final Long popupsId) {
+        if (popupsId == null) {
+            return null;
+        }
+
+        return popups.id.lt(popupsId);
+    }
+
+    private BooleanExpression eqPublicTagsWithPopups(final List<PublicTag> publicTags) {
+        if (publicTags.isEmpty()) {
+            return null;
+        }
+
+        return popups.publicTag.in(publicTags);
+    }
+
+    private BooleanExpression eqCitiesWithPopups(final List<String> cities) {
+        if (cities.isEmpty()) {
+            return null;
+        }
+
+        return cities.stream()
+                .map(popups.position.location::startsWith)
+                .reduce(BooleanExpression::or)
+                .orElse(null);
+    }
+}

--- a/backend/pcloud-domain/src/main/java/com/domain/show/show/infrastructure/ShowQueryRepository.java
+++ b/backend/pcloud-domain/src/main/java/com/domain/show/show/infrastructure/ShowQueryRepository.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.domain.show.exhibition.domain.QExhibition.exhibition;
@@ -26,16 +27,18 @@ public class ShowQueryRepository {
             final Integer pageSize,
             final ShowType showType,
             final List<PublicTag> publicTags,
-            final List<String> cities
+            final List<String> cities,
+            final LocalDateTime startDate,
+            final LocalDateTime endDate
     ) {
         if (showType.equals(ShowType.EXHIBITION)) {
-            return fetchExhibition(showId, pageSize, publicTags, cities);
+            return fetchExhibition(showId, pageSize, publicTags, cities, startDate, endDate);
         }
 
-        return fetchPopups(showId, pageSize, publicTags, cities);
+        return fetchPopups(showId, pageSize, publicTags, cities, startDate, endDate);
     }
 
-    private List<ShowSimpleResponse> fetchExhibition(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities) {
+    private List<ShowSimpleResponse> fetchExhibition(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities, final LocalDateTime startDate, final LocalDateTime endDate) {
         return jpaQueryFactory.select(constructor(ShowSimpleResponse.class,
                         exhibition.id,
                         Expressions.constant(ShowType.EXHIBITION),
@@ -50,7 +53,8 @@ public class ShowQueryRepository {
                 .where(
                         ltExhibitionId(showId),
                         eqPublicTags(publicTags),
-                        eqCities(cities)
+                        eqCities(cities),
+                        exhibition.showSchedule.endDate.between(startDate, endDate)
                 )
                 .orderBy(exhibition.id.desc())
                 .limit(pageSize)
@@ -84,7 +88,7 @@ public class ShowQueryRepository {
                 .orElse(null);
     }
 
-    private List<ShowSimpleResponse> fetchPopups(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities) {
+    private List<ShowSimpleResponse> fetchPopups(final Long showId, final Integer pageSize, final List<PublicTag> publicTags, final List<String> cities, final LocalDateTime startDate, final LocalDateTime endDate) {
         return jpaQueryFactory.select(constructor(ShowSimpleResponse.class,
                         popups.id,
                         Expressions.constant(ShowType.POPUPS),
@@ -99,7 +103,8 @@ public class ShowQueryRepository {
                 .where(
                         ltPopupsId(showId),
                         eqPublicTagsWithPopups(publicTags),
-                        eqCitiesWithPopups(cities)
+                        eqCitiesWithPopups(cities),
+                        popups.showSchedule.endDate.between(startDate, endDate)
                 )
                 .orderBy(popups.id.desc())
                 .limit(pageSize)

--- a/backend/pcloud-domain/src/test/java/com/domain/show/exhibition/infrastructure/ExhibitionQueryRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/show/exhibition/infrastructure/ExhibitionQueryRepositoryTest.java
@@ -1,26 +1,19 @@
 package com.domain.show.exhibition.infrastructure;
 
-import com.domain.show.exhibition.domain.Exhibition;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
-import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import com.domain.helper.IntegrationHelper;
-import show.exhibition.domain.ExhibitionSimpleResponseFixture;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.LongStream;
+import com.domain.show.exhibition.domain.Exhibition;
+import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전;
-import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
-import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성_개인전시회;
+import java.math.BigDecimal;
+import java.util.Optional;
+
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전;
+import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성_개인전시회;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -50,65 +43,5 @@ class ExhibitionQueryRepositoryTest extends IntegrationHelper {
                     .withComparatorForType(BigDecimal::compareTo, BigDecimal.class)
                     .isEqualTo(개인전시회_상세_조회_응답_생성_개인전시회(savedExhibition));
         });
-    }
-
-    @Nested
-    class 개인전시회_페이징_조회 {
-
-        @Test
-        void 첫_번째_페이징_조회_시_exhibition_id값이_null로_조회된다() {
-            // given
-            List<Exhibition> exhibitions = createExhibitions(20);
-            int pageSize = 10;
-            List<ExhibitionSimpleResponse> expectedResponses = exhibitions.stream()
-                    .sorted(Comparator.comparing(Exhibition::getId).reversed())
-                    .limit(pageSize)
-                    .map(ExhibitionSimpleResponseFixture::개인전시회_간단_조회_응답_생성_개인전시회)
-                    .toList();
-
-            // when
-            List<ExhibitionSimpleResponse> responses = exhibitionQueryRepository.findAllWithPaging(null, pageSize);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(responses).hasSize(pageSize);
-                softly.assertThat(responses)
-                        .containsExactlyElementsOf(expectedResponses);
-            });
-        }
-
-        @Test
-        void 첫_번째_페이징_조회가_아닐_경우_exhibition_id값으로_페이징_조회가된다() {
-            // given
-            List<Exhibition> exhibitions = createExhibitions(15);
-            Long exhibitionId = 12L;
-            int pageSize = 3;
-            List<ExhibitionSimpleResponse> expectedResponses = exhibitions.stream()
-                    .sorted(Comparator.comparing(Exhibition::getId).reversed())
-                    .filter(exhibition -> exhibition.getId() < exhibitionId)
-                    .limit(pageSize)
-                    .map(ExhibitionSimpleResponseFixture::개인전시회_간단_조회_응답_생성_개인전시회)
-                    .toList();
-
-            // when
-            List<ExhibitionSimpleResponse> responses = exhibitionQueryRepository.findAllWithPaging(exhibitionId, pageSize);
-
-            // then
-            assertSoftly(softly -> {
-                softly.assertThat(responses).hasSize(pageSize);
-                softly.assertThat(responses)
-                        .containsExactlyElementsOf(expectedResponses);
-            });
-        }
-
-        private List<Exhibition> createExhibitions(final int count) {
-            List<Exhibition> exhibitions = new ArrayList<>();
-            LongStream.rangeClosed(1, count)
-                    .forEach(index -> {
-                        Exhibition savedExhibition = exhibitionJpaRepository.save(개인전시회_생성_사진_개인전_작성자아이디(index));
-                        exhibitions.add(savedExhibition);
-                    });
-            return exhibitions;
-        }
     }
 }

--- a/backend/pcloud-domain/src/test/java/com/domain/show/popups/infrastructure/PopupsQueryRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/show/popups/infrastructure/PopupsQueryRepositoryTest.java
@@ -2,19 +2,16 @@ package com.domain.show.popups.infrastructure;
 
 import com.domain.helper.IntegrationHelper;
 import com.domain.show.popups.domain.Popups;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.LongStream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static show.popups.domain.PopupsFixture.일반_팝업_스토어_생성_뷰티;
-import static show.popups.domain.PopupsFixture.일반_팝업_스토어_생성_펫샵_작성자아이디;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -38,40 +35,6 @@ class PopupsQueryRepositoryTest extends IntegrationHelper {
         assertSoftly(softly -> {
             softly.assertThat(response).isPresent();
             softly.assertThat(response.get().id()).isEqualTo(savedPopups.getId());
-        });
-    }
-
-    @Test
-    void no_offset_페이징_첫_조회() {
-        // given
-        LongStream.rangeClosed(1, 20)
-                .forEach(index -> popupsJpaRepository.save(일반_팝업_스토어_생성_펫샵_작성자아이디(index)));
-
-        // when
-        List<PopupsSimpleResponse> result = popupsQueryRepository.findAllWithPaging(null, 10);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(10);
-            softly.assertThat(result.get(0).id()).isEqualTo(20L);
-            softly.assertThat(result.get(9).id()).isEqualTo(11L);
-        });
-    }
-
-    @Test
-    void no_offset_페이징_두번째_조회() {
-        // given
-        LongStream.rangeClosed(1, 20)
-                .forEach(index -> popupsJpaRepository.save(일반_팝업_스토어_생성_펫샵_작성자아이디(index)));
-
-        // when
-        List<PopupsSimpleResponse> result = popupsQueryRepository.findAllWithPaging(11L, 10);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(10);
-            softly.assertThat(result.get(0).id()).isEqualTo(10L);
-            softly.assertThat(result.get(9).id()).isEqualTo(1L);
         });
     }
 }

--- a/backend/pcloud-domain/src/test/java/com/domain/show/show/infrastructure/ShowQueryRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/show/show/infrastructure/ShowQueryRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.domain.show.show.infrastructure;
+
+import com.domain.helper.IntegrationHelper;
+import com.domain.show.common.ShowType;
+import com.domain.show.exhibition.infrastructure.ExhibitionJpaRepository;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static show.exhibition.domain.ExhibitionFixture.개인전시회_생성_사진_개인전_작성자아이디;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class ShowQueryRepositoryTest extends IntegrationHelper {
+
+    @Autowired
+    private ShowQueryRepository showQueryRepository;
+
+    @Autowired
+    private ExhibitionJpaRepository exhibitionJpaRepository;
+
+    @Nested
+    class 개인전시회_페이징_조회 {
+
+        @Test
+        void 첫_번째_페이징_조회_시_exhibition_id값이_null로_조회된다() {
+            // given
+            createExhibitions(20);
+            int pageSize = 10;
+
+            // when
+            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(null, pageSize, ShowType.EXHIBITION, List.of(), List.of());
+
+            // then
+            assertThat(responses).hasSize(pageSize);
+        }
+
+        @Test
+        void 첫_번째_페이징_조회가_아닐_경우_exhibition_id값으로_페이징_조회가된다() {
+            // given
+            createExhibitions(15);
+            Long exhibitionId = 12L;
+            int pageSize = 3;
+
+            // when
+            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(exhibitionId, pageSize, ShowType.EXHIBITION, List.of(), List.of());
+
+            // then
+            assertThat(responses).hasSize(pageSize);
+        }
+
+        private void createExhibitions(final int count) {
+            LongStream.rangeClosed(1, count)
+                    .forEach(index -> exhibitionJpaRepository.save(개인전시회_생성_사진_개인전_작성자아이디(index)));
+        }
+    }
+}

--- a/backend/pcloud-domain/src/test/java/com/domain/show/show/infrastructure/ShowQueryRepositoryTest.java
+++ b/backend/pcloud-domain/src/test/java/com/domain/show/show/infrastructure/ShowQueryRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.LongStream;
 
@@ -36,7 +37,7 @@ class ShowQueryRepositoryTest extends IntegrationHelper {
             int pageSize = 10;
 
             // when
-            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(null, pageSize, ShowType.EXHIBITION, List.of(), List.of());
+            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(null, pageSize, ShowType.EXHIBITION, List.of(), List.of(), LocalDateTime.of(2024, 1, 1, 0, 0), LocalDateTime.of(2025, 1, 1, 0, 0));
 
             // then
             assertThat(responses).hasSize(pageSize);
@@ -50,7 +51,7 @@ class ShowQueryRepositoryTest extends IntegrationHelper {
             int pageSize = 3;
 
             // when
-            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(exhibitionId, pageSize, ShowType.EXHIBITION, List.of(), List.of());
+            List<ShowSimpleResponse> responses = showQueryRepository.findAllWithPaging(exhibitionId, pageSize, ShowType.EXHIBITION, List.of(), List.of(), LocalDateTime.of(2024, 1, 1, 0, 0), LocalDateTime.of(2025, 1, 1, 0, 0));
 
             // then
             assertThat(responses).hasSize(pageSize);

--- a/backend/pcloud-domain/src/testFixtures/java/show/exhibition/infrasturcture/ExhibitionFakeRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/show/exhibition/infrasturcture/ExhibitionFakeRepository.java
@@ -3,14 +3,11 @@ package show.exhibition.infrasturcture;
 import com.domain.show.exhibition.domain.Exhibition;
 import com.domain.show.exhibition.domain.ExhibitionRepository;
 import com.domain.show.exhibition.domain.LikedExhibition;
-import com.domain.show.exhibition.domain.dto.ExhibitionSimpleResponse;
 import com.domain.show.exhibition.domain.dto.ExhibitionSpecificResponse;
-import java.util.Comparator;
+
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import show.exhibition.domain.ExhibitionSimpleResponseFixture;
 
 import static show.exhibition.domain.ExhibitionSpecificResponseFixture.개인전시회_상세_조회_응답_생성_개인전시회;
 
@@ -70,17 +67,6 @@ public class ExhibitionFakeRepository implements ExhibitionRepository {
         ExhibitionSpecificResponse response = 개인전시회_상세_조회_응답_생성_개인전시회(exhibition);
 
         return Optional.of(response);
-    }
-
-    @Override
-    public List<ExhibitionSimpleResponse> findAllWithPaging(final Long exhibitionId, final Integer pageSize) {
-        return exhibitionDB.values()
-                .stream()
-                .filter(exhibition -> exhibition.getId() < exhibitionId)
-                .sorted(Comparator.comparing(Exhibition::getId).reversed())
-                .limit(pageSize)
-                .map(ExhibitionSimpleResponseFixture::개인전시회_간단_조회_응답_생성_개인전시회)
-                .toList();
     }
 
     @Override

--- a/backend/pcloud-domain/src/testFixtures/java/show/popups/infrastructure/FakePopupsRepository.java
+++ b/backend/pcloud-domain/src/testFixtures/java/show/popups/infrastructure/FakePopupsRepository.java
@@ -3,12 +3,9 @@ package show.popups.infrastructure;
 import com.domain.show.popups.domain.LikedPopups;
 import com.domain.show.popups.domain.Popups;
 import com.domain.show.popups.domain.PopupsRepository;
-import com.domain.show.popups.domain.response.PopupsSimpleResponse;
 import com.domain.show.popups.domain.response.PopupsSpecificResponse;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -59,21 +56,6 @@ public class FakePopupsRepository implements PopupsRepository {
         PopupsSpecificResponse response = 팝업스토어_상세_조회_응답_생성_팝업스토어(popups);
 
         return Optional.of(response);
-    }
-
-    @Override
-    public List<PopupsSimpleResponse> findAllWithPaging(final Long popupsId, final Integer pageSize) {
-        return List.of(
-                new PopupsSimpleResponse(
-                        1L,
-                        "빵빵이 전시회",
-                        "서울시 마포구",
-                        LocalDateTime.now().minusDays(100),
-                        LocalDateTime.now(),
-                        0,
-                        0
-                )
-        );
     }
 
     @Override

--- a/backend/pcloud-domain/src/testFixtures/java/show/show/domain/dto/ShowSimpleResponseFixture.java
+++ b/backend/pcloud-domain/src/testFixtures/java/show/show/domain/dto/ShowSimpleResponseFixture.java
@@ -1,0 +1,24 @@
+package show.show.domain.dto;
+
+import com.domain.show.common.PublicTag;
+import com.domain.show.common.ShowType;
+import com.domain.show.show.domain.dto.ShowSimpleResponse;
+
+import java.time.LocalDateTime;
+
+public class ShowSimpleResponseFixture {
+
+    public static ShowSimpleResponse 쇼_페이징_요소_반환() {
+        return new ShowSimpleResponse(
+                1L,
+                ShowType.EXHIBITION,
+                PublicTag.ARTIST,
+                "빵빵이와 놀아요",
+                "서울 동작구",
+                LocalDateTime.of(2024, 01, 01, 9, 00),
+                LocalDateTime.of(2024, 03, 01, 6, 00),
+                0,
+                0
+        );
+    }
+}


### PR DESCRIPTION
## 📄 Summary

### 요약
- 기존 팝업스토어, 전시회 페이징 조회를 `쇼케이스 no-offset 기반 페이징 조회`로 합쳤습니다.
- 프론트엔드의 요구사항에 맞게 Param에 `지역, 날짜`를 추가했습니다.

### 필요한 파람
- showId: Number -> 초기 보낼 때 필요없음
- pageSize: Number
- showType: String (default = popups, values = {popups, exhibition, all -> all 아직 지원 안함})
- publicTags: String (쇼케이스 태그)
- city: String (도시 (ex. 서울, 경기도 ...))
- country: arr (지역 (ex. 마포구, 성동구 ...))
- startDate: String (nullable = false) -> ex => 2024-01-01
- endDate: String (nullable = false) -> ex => 2024-12-31

## 🙋🏻 More

### Todo
이슈를 따로 생성해 추가 작업이 필요합니다.
https://github.com/sosow0212/2024-pop-cloud/issues/77

- 인덱스를 통한 성능 개선
- 너무 많은 Parameter를 관리하는 별도의 클래스 생성
- 코드 리팩토링 작업
- ALL 태그 지원


close #75